### PR TITLE
refactor: improve tool guidance in templates

### DIFF
--- a/templates/assistant/commands/tasks/create-plan.md
+++ b/templates/assistant/commands/tasks/create-plan.md
@@ -10,7 +10,9 @@ ensuring you have all necessary context before proceeding. Use the plan-creator 
 
 ---
 
-Ultrathink, think harder, and use tools.
+Use tools for the planning. You are encouraged to write your own specialized tools to research, analyze, and debug
+any work order from the user. You are not restricted to the stack of the current project to create your own
+specialized tools.
 
 ## Find the AI Task Manager root
 

--- a/templates/assistant/commands/tasks/fix-broken-tests.md
+++ b/templates/assistant/commands/tasks/fix-broken-tests.md
@@ -3,7 +3,11 @@ argument-hint: "[testCommand]"
 description: Fix the tests your task execution broke.
 ---
 
-Fix all failing tests in this repository. Ultrathink, think harder, and use tools.
+Fix all failing tests in this repository.
+
+Use tools for debugging. You are encouraged to write your own specialized tools to research, analyze, and debug
+failing tests. You are not restricted to the stack of the current project to create your own
+specialized tools.
 
 Execute this command to run the tests:
 

--- a/templates/assistant/commands/tasks/generate-tasks.md
+++ b/templates/assistant/commands/tasks/generate-tasks.md
@@ -7,8 +7,6 @@ description: Generate tasks to implement the plan with the provided ID.
 
 ---
 
-Ultrathink, think harder, and use tools.
-
 ## Find the AI Task Manager root
 
 ```bash

--- a/templates/assistant/commands/tasks/refine-plan.md
+++ b/templates/assistant/commands/tasks/refine-plan.md
@@ -11,7 +11,9 @@ user, and update the plan with the refinements. Use the plan-creator sub-agent f
 
 ---
 
-Ultrathink, think harder, and use tools.
+Use tools for the plan refinement. You are encouraged to write your own specialized tools to research, analyze, and
+debug any plan refinement. You are not restricted to the stack of the current project to create your own specialized
+tools.
 
 ## Find the AI Task Manager root
 


### PR DESCRIPTION
## Summary
- Replace vague "Ultrathink, think harder, and use tools" directive with specific, context-appropriate tool guidance across all command templates
- Each template now encourages assistants to create their own specialized tools for research, analysis, and debugging
- Fixed "expecialized" typo introduced during the rewrite

## Test plan
- [x] All 178 tests pass
- [x] Lint passes