### PR TITLE
feat: add Self Validation section to plan template

### DIFF
--- a/templates/ai-task-manager/config/hooks/POST_EXECUTION.md
+++ b/templates/ai-task-manager/config/hooks/POST_EXECUTION.md
@@ -8,6 +8,7 @@ Before marking the blueprint as complete, verify:
 - [ ] All tests must pass successfully. If no test suite is configured, skip this step
 - [ ] Verify all tasks in the plan have `status: "completed"` in their frontmatter
 - [ ] Verify that the AGENTS.md documentation or related documentes are still correct after this plan execution
+- [ ] Execute the **Self Validation** steps defined in the plan document. These are concrete verification procedures (e.g., Playwright browser checks, database CLI queries, screenshots) that confirm the implementation works in the real system. If any step fails, treat it as a validation gate failure
 
 ## Failure Behavior
 

--- a/templates/ai-task-manager/config/templates/PLAN_TEMPLATE.md
+++ b/templates/ai-task-manager/config/templates/PLAN_TEMPLATE.md
@@ -74,6 +74,19 @@ Example:
 2. [Measurable outcome 2]
 3. [Measurable outcome 3]
 
+## Self Validation
+
+[Describe the concrete steps an LLM should execute after all tasks are completed to verify the implementation works correctly. These must be actionable verification procedures that inspect the real system — not just running pre-existing tests.
+
+Examples of good validation steps:
+- Use Playwright CLI to open a browser, navigate to the affected pages, and take screenshots to confirm the UI renders correctly
+- Run a CLI command to query the database and verify the expected configuration or content exists
+- Use `curl` or a browser automation tool to exercise the new API endpoints and confirm correct responses
+- Take a screenshot of the form/page/component and visually verify the expected elements are present
+- Run the application and interact with the new feature end-to-end, capturing evidence of success
+
+Avoid vague statements like "verify it works" or "ensure quality". Each step must be a specific, executable action.]
+
 ## Documentation
 
 [Required documentation updates to existing documentation, either human-focused documentation, the project's README.md or assistant-focused documentation like AGENTS.md, .claude/skills/* for the site, etc.]


### PR DESCRIPTION
## Summary
- Adds a **Self Validation** section to `PLAN_TEMPLATE.md` where the LLM defines concrete steps to verify the implementation works after all tasks are executed (e.g., Playwright browser checks, database CLI queries, screenshots)
- Updates `POST_EXECUTION.md` hook to enforce executing those validation steps as a blocking gate before archival

## Test plan
- [x] All existing tests pass (178/178)
- [ ] Run `npx . init --assistants claude --destination-directory /tmp/test` and verify the new Self Validation section appears in the generated plan template
- [ ] Create a plan and confirm the LLM fills in the Self Validation section with actionable steps
- [ ] Execute a blueprint and confirm the POST_EXECUTION hook runs the Self Validation steps
