### PR TITLE
docs: fix 1.x workspace paths in migration guide

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -24,7 +24,7 @@ rm -rf ".claude/commands/tasks/" \
 
 ## 2. Delete obsolete config scripts
 
-In 1.x the workspace lived under `.ai/task-manager/`, so the scripts to remove are there:
+In 1.x and 2.x the workspace lived under `.ai/task-manager/`, so the scripts to remove are there:
 
 ```bash
 rm -f .ai/task-manager/config/scripts/*.cjs
@@ -33,7 +33,7 @@ rmdir .ai/task-manager/config/scripts 2>/dev/null
 
 ## 3. Rename the workspace directory
 
-2.x+ uses `.ai/strikethroo/` instead of `.ai/task-manager/`. Rename the directory so your existing plans, archive, and config carry over:
+3.x+ uses `.ai/strikethroo/` instead of `.ai/task-manager/`. Rename the directory so your existing plans, archive, and config carry over:
 
 ```bash
 mv .ai/task-manager .ai/strikethroo

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -24,12 +24,22 @@ rm -rf ".claude/commands/tasks/" \
 
 ## 2. Delete obsolete config scripts
 
+In 1.x the workspace lived under `.ai/task-manager/`, so the scripts to remove are there:
+
 ```bash
-rm -f .ai/strikethroo/config/scripts/*.cjs
-rmdir .ai/strikethroo/config/scripts 2>/dev/null
+rm -f .ai/task-manager/config/scripts/*.cjs
+rmdir .ai/task-manager/config/scripts 2>/dev/null
 ```
 
-## 3. Re-initialize the workspace
+## 3. Rename the workspace directory
+
+2.x+ uses `.ai/strikethroo/` instead of `.ai/task-manager/`. Rename the directory so your existing plans, archive, and config carry over:
+
+```bash
+mv .ai/task-manager .ai/strikethroo
+```
+
+## 4. Re-initialize the workspace
 
 ```bash
 npx strikethroo@latest init --harnesses claude
@@ -37,7 +47,7 @@ npx strikethroo@latest init --harnesses claude
 
 Replace `claude` with your harness(es), e.g. `claude,gemini,opencode`.
 
-## 4. Install the workflow skills
+## 5. Install the workflow skills
 
 ```bash
 npx skills add e0ipso/strikethroo


### PR DESCRIPTION
## Summary
- Fixes step 2 to remove config scripts from `.ai/task-manager/config/scripts` (the 1.x workspace location) instead of `.ai/strikethroo/config/scripts`
- Adds a new step to rename `.ai/task-manager` → `.ai/strikethroo` before re-initializing, so existing plans and archive carry over
- Renumbers the remaining steps accordingly

Closes #22

## Test plan
- [x] Verified the corrected paths and rename step against a real 1.x → 3.x upgrade