### PR TITLE
fix: use composite plan name for task links

### DIFF
--- a/src/__tests__/zero-padding.e2e.test.ts
+++ b/src/__tests__/zero-padding.e2e.test.ts
@@ -1,0 +1,145 @@
+/**
+ * End-to-end regression for zero-padded plan ids.
+ *
+ * Verifies that UI paths derived from a plan's composite directory name keep
+ * any leading zeros, so copied commands and task navigation work. This
+ * prevents issue #24-style mismatches where the displayed/copied path used the
+ * unpadded numeric id instead of the actual directory name.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { test, expect } from '@playwright/test';
+import { startServer, ServeHandle } from '../serve/server';
+
+const ASSETS_DIR = path.resolve(process.cwd(), 'dist-web');
+const INDEX_HTML = path.join(ASSETS_DIR, 'index.html');
+const assetsBuilt = fs.existsSync(INDEX_HTML);
+
+interface PlanSeed {
+  id: number;
+  slug: string;
+  taskStatus?: string;
+}
+
+/**
+ * Seeds a workspace with two zero-padded plans:
+ *   - one drafted plan with no tasks (for the self-review modal test)
+ *   - one ready plan with a single pending task (for task navigation)
+ */
+const makeFixtureWorkspace = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'st-zero-padding-fixture-'));
+
+  const writePlan = ({ id, slug, taskStatus }: PlanSeed): void => {
+    const padded = String(id).padStart(2, '0');
+    const planDir = path.join(root, 'plans', `${padded}--${slug}`);
+    const tasksDir = path.join(planDir, 'tasks');
+    fs.mkdirSync(tasksDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(planDir, `plan-${padded}--${slug}.md`),
+      `---\nid: ${id}\nsummary: "Fixture ${slug}"\ncreated: "2026-06-02"\n---\n\n# ${slug}\n\nPlan body.\n`
+    );
+    if (taskStatus) {
+      fs.writeFileSync(
+        path.join(tasksDir, '01--first-task.md'),
+        `---\nid: 1\ngroup: "fixture"\ndependencies: []\nstatus: "${taskStatus}"\ncreated: "2026-06-02"\nskills: []\n---\n# First task\n`
+      );
+    }
+  };
+
+  writePlan({ id: 4, slug: 'ai-summary-cost-guardrail' }); // drafted
+  writePlan({ id: 5, slug: 'task-nav-fixture', taskStatus: 'pending' }); // ready
+
+  return root;
+};
+
+test.describe('Zero-padded plan ids (Playwright)', () => {
+  test.skip(!assetsBuilt, 'dist-web not built');
+  test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
+
+  let handle: ServeHandle;
+  let root: string;
+  let fakeBinDir: string;
+  let originalPath: string | undefined;
+
+  test.beforeAll(async () => {
+    // Make a fake `self-review` binary available on PATH so the server reports
+    // the capability as installed and the SPA renders the launcher variant.
+    fakeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'st-fake-self-review-'));
+    const fakeBinary = path.join(fakeBinDir, 'self-review');
+    fs.writeFileSync(fakeBinary, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    originalPath = process.env.PATH;
+    process.env.PATH = `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ''}`;
+
+    root = makeFixtureWorkspace();
+    handle = await startServer({
+      root,
+      port: 0,
+      open: false,
+      assetsDir: ASSETS_DIR,
+      debounceMs: 150,
+    });
+  });
+
+  test.afterAll(async () => {
+    await new Promise<void>(r => handle.server.close(() => r()));
+    if (root) fs.rmSync(root, { recursive: true, force: true });
+    if (fakeBinDir) fs.rmSync(fakeBinDir, { recursive: true, force: true });
+    process.env.PATH = originalPath;
+  });
+
+  test('Review modal command preserves leading zeros in the plan path', async ({ page }) => {
+    page.setDefaultTimeout(15_000);
+    try {
+      await page.goto(handle.url, { waitUntil: 'domcontentloaded' });
+
+      // Switch to Cards view and open the Review modal for the drafted plan.
+      await page.getByText('Cards', { exact: true }).click();
+      await page.getByTestId('plan-card').first().waitFor();
+      await page.getByRole('button', { name: /Review in self-review/ }).click();
+
+      const dialog = page.getByRole('dialog');
+      await dialog.waitFor();
+
+      // The displayed command must include the zero-padded directory name.
+      const text = (await dialog.textContent()) ?? '';
+      expect(text).toContain('.ai/strikethroo/plans/04--ai-summary-cost-guardrail/');
+      expect(text).toContain('plan-04--ai-summary-cost-guardrail.md');
+      expect(text).not.toContain('plans/4--ai-summary-cost-guardrail/');
+      expect(text).not.toContain('plan-4--ai-summary-cost-guardrail.md');
+
+      // The copied clipboard text must match the displayed command.
+      await dialog.getByRole('button', { name: 'Copy command to clipboard' }).click();
+      const clip = await page.evaluate(() => navigator.clipboard.readText());
+      expect(clip).toBe(
+        'self-review .ai/strikethroo/plans/04--ai-summary-cost-guardrail/plan-04--ai-summary-cost-guardrail.md'
+      );
+    } finally {
+      await page.close();
+    }
+  });
+
+  test('Tasks-tab task navigation keeps the composite zero-padded plan name', async ({ page }) => {
+    page.setDefaultTimeout(15_000);
+    try {
+      await page.goto(`${handle.url}/plans/05--task-nav-fixture`, {
+        waitUntil: 'domcontentloaded',
+      });
+
+      // Switch to the Tasks tab.
+      await page.getByRole('tab', { name: /Tasks/ }).click();
+      await page.getByTestId('swimlanes').waitFor();
+
+      // Click the first lane task; the detail route must use the composite name.
+      await page.getByTestId('lane-task').first().click();
+      await page.waitForFunction(
+        () => /^\/plans\/05--task-nav-fixture\/tasks\/\d+$/.test(location.pathname),
+        { timeout: 5_000 }
+      );
+      expect(page.url()).toContain('/plans/05--task-nav-fixture/tasks/');
+    } finally {
+      await page.close();
+    }
+  });
+});

--- a/src/web/plans/__tests__/derive.test.ts
+++ b/src/web/plans/__tests__/derive.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for the Plans-section derivation layer (`src/web/plans/derive.ts`).
+ *
+ * Covers the helpers that adapt API plan summaries into view-facing shapes and
+ * build workspace-relative paths. These are pure functions, so the tests are
+ * fast and deterministic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { planMdPath, stripIdPrefix, humanizeSlug, mapPlan, type PlanView } from '../derive';
+import type { PlanSummary } from '../../data/api';
+
+const summary = (overrides: Partial<PlanSummary> = {}): PlanSummary => ({
+  id: 4,
+  name: '04--ai-summary-cost-guardrail',
+  summary: 'AI summary cost guardrail',
+  created: '2026-06-02',
+  state: 'drafted',
+  done: 0,
+  total: 0,
+  phaseCount: 0,
+  archived: false,
+  ...overrides,
+});
+
+describe('stripIdPrefix', () => {
+  it('removes a numeric id prefix from a composite plan name', () => {
+    expect(stripIdPrefix('04--ai-summary-cost-guardrail')).toBe('ai-summary-cost-guardrail');
+    expect(stripIdPrefix('123--some-plan')).toBe('some-plan');
+  });
+
+  it('returns the input unchanged when there is no prefix', () => {
+    expect(stripIdPrefix('no-prefix-here')).toBe('no-prefix-here');
+  });
+});
+
+describe('humanizeSlug', () => {
+  it('converts kebab-case slugs to Title Case', () => {
+    expect(humanizeSlug('ai-summary-cost-guardrail')).toBe('Ai Summary Cost Guardrail');
+  });
+
+  it('handles underscores and multiple separators', () => {
+    expect(humanizeSlug('some_plan-name')).toBe('Some Plan Name');
+  });
+});
+
+describe('mapPlan', () => {
+  it('preserves the composite directory name exactly as returned by the API', () => {
+    const view = mapPlan(summary());
+    expect(view.name).toBe('04--ai-summary-cost-guardrail');
+    expect(view.id).toBe(4);
+  });
+
+  it('maps zero-task plans to null counts while preserving the reported state', () => {
+    const view = mapPlan(summary({ state: 'doing', done: 0, total: 0 }));
+    expect(view.state).toBe('doing');
+    expect(view.done).toBeNull();
+    expect(view.total).toBeNull();
+  });
+});
+
+describe('planMdPath', () => {
+  it('builds a workspace-relative markdown path from the composite directory name', () => {
+    const view: PlanView = {
+      id: 4,
+      name: '04--ai-summary-cost-guardrail',
+      slug: 'ai-summary-cost-guardrail',
+      title: 'Ai Summary Cost Guardrail',
+      summary: 'AI summary cost guardrail',
+      state: 'drafted',
+      done: null,
+      total: null,
+      phases: null,
+      created: '2026-06-02',
+    };
+
+    expect(planMdPath(view)).toBe(
+      '.ai/strikethroo/plans/04--ai-summary-cost-guardrail/plan-04--ai-summary-cost-guardrail.md'
+    );
+  });
+
+  it('preserves leading zeros in the plan directory name (regression for #24)', () => {
+    expect(planMdPath({ name: '04--short' })).toBe(
+      '.ai/strikethroo/plans/04--short/plan-04--short.md'
+    );
+    expect(planMdPath({ name: '007--extra-padded' })).toBe(
+      '.ai/strikethroo/plans/007--extra-padded/plan-007--extra-padded.md'
+    );
+  });
+
+  it('falls back to a placeholder when no name is supplied', () => {
+    expect(planMdPath({ name: '' })).toBe('.ai/strikethroo/plans/NN--slug/plan-NN--slug.md');
+  });
+});

--- a/src/web/plans/__tests__/taskNav.test.ts
+++ b/src/web/plans/__tests__/taskNav.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Unit tests for task navigation helpers (`src/web/plans/taskNav.ts`).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { taskNavProps } from '../taskNav';
+
+const mockNavigate = vi.fn();
+
+describe('taskNavProps', () => {
+  it('navigates to the composite plan name route, preserving zero-padded ids', () => {
+    const props = taskNavProps('04--ai-summary-cost-guardrail', 1, mockNavigate);
+    expect(props).not.toBeNull();
+    props!.onClick();
+    expect(mockNavigate).toHaveBeenCalledWith('/plans/04--ai-summary-cost-guardrail/tasks/1');
+  });
+
+  it('returns null for tasks without an id', () => {
+    expect(taskNavProps('04--ai-summary-cost-guardrail', undefined, mockNavigate)).toBeNull();
+  });
+
+  it('URL-encodes the plan name segment', () => {
+    taskNavProps('04--name with spaces', 2, mockNavigate)!.onClick();
+    expect(mockNavigate).toHaveBeenCalledWith('/plans/04--name%20with%20spaces/tasks/2');
+  });
+});

--- a/src/web/plans/exec/ExecuteTab.tsx
+++ b/src/web/plans/exec/ExecuteTab.tsx
@@ -14,5 +14,5 @@ import { ExecSwimlanesView } from './ExecSwimlanesView';
 
 /** The Tasks tab body: the Swimlanes Execution-blueprint view. */
 export function ExecuteTab({ detail }: { detail: PlanDetail }) {
-  return <ExecSwimlanesView planId={String(detail.id)} detail={detail} />;
+  return <ExecSwimlanesView planId={detail.name} detail={detail} />;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,8 @@ export default defineConfig({
       'src/web/__tests__/router.test.ts',
       'src/web/archive/__tests__/helpers.test.tsx',
       'src/web/components/__tests__/railCollapse.test.ts',
+      'src/web/plans/__tests__/derive.test.ts',
+      'src/web/plans/__tests__/taskNav.test.ts',
       'src/web/plans/exec/__tests__/derive.test.ts',
       'src/web/theme/__tests__/theme.test.ts',
     ],


### PR DESCRIPTION
The Tasks-tab swimlanes passed String(detail.id) as the planId, producing task-detail URLs from the bare numeric id, which no longer resolve under the composite {id}--{slug} routing contract. Pass detail.name so links address the canonical plan key.

Add unit coverage for taskNav and plans derive helpers, an e2e regression for zero-padded ids, and wire the new unit suites into vitest.config.