### PR TITLE
docs: add Cursor Cloud setup instructions to AGENTS.md

### DIFF
--- a/.cursor/cloud-instructions.md
+++ b/.cursor/cloud-instructions.md
@@ -1,0 +1,10 @@
+# Cursor Cloud specific instructions
+
+Durable, non-obvious setup/run caveats for developing this repo inside a Cursor Cloud Agent VM. Standard commands live in [`AGENTS.md`](../AGENTS.md) (`## Quick Start`, `## Build Pipeline`, `## Testing`).
+
+Dependencies are installed automatically on VM startup (`npm install`). Node 22+ is present.
+
+- **Build before running the CLI or `serve`.** `npm install` only runs `husky`. Run `npm run build` (see `## Build Pipeline`) to produce `dist/` + `dist-web/` before `node dist/cli.js …`. `npm run test:unit` and `npm run lint` run against `src/` and need no build.
+- **`serve` requires an initialized workspace.** It resolves `<project>/.ai/strikethroo/.init-metadata.json` (walks upward from cwd, or use `--workspace <projectDir>`). To get content to view: `node dist/cli.js init --harnesses claude --destination-directory <dir> --force`, then `node dist/cli.js serve --no-open --port 4317 --workspace <dir>`. The fixture workspace at `src/capture/fixtures/capture-workspace/` is laid out flat (no `.ai/strikethroo/` wrapper) so it is **not** directly servable — copy its `plans/`+`archive/` into an initialized workspace to demo real data.
+- **e2e self-installs its browser.** `npm run test:e2e` runs `pretest:e2e` (`playwright install --with-deps chromium`) first; unit (190) and e2e (36) suites pass green here.
+- Hot-reloading dev viewer: `npm run dev:serve` (ts-node, `--no-open`).

--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,9 @@ review.xml
 
 # AI Assistants
 .opencode
-.cursor
+.cursor/*
+# Track the offloaded Cursor Cloud instructions (loaded on demand from AGENTS.md)
+!.cursor/cloud-instructions.md
 .claude
 .agents/skills/
 skills-lock.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,12 +231,7 @@ Custom error classes (`src/types.ts`): `FileSystemError`, `ConfigError`, `Templa
 
 ## Cursor Cloud specific instructions
 
-Dependencies are installed automatically on VM startup (`npm install`). Node 22+ is present.
-
-- **Build before running the CLI or `serve`.** `npm install` only runs `husky`. Run `npm run build` (see `## Build Pipeline`) to produce `dist/` + `dist-web/` before `node dist/cli.js …`. `npm run test:unit` and `npm run lint` run against `src/` and need no build.
-- **`serve` requires an initialized workspace.** It resolves `<project>/.ai/strikethroo/.init-metadata.json` (walks upward from cwd, or use `--workspace <projectDir>`). To get content to view: `node dist/cli.js init --harnesses claude --destination-directory <dir> --force`, then `node dist/cli.js serve --no-open --port 4317 --workspace <dir>`. The fixture workspace at `src/capture/fixtures/capture-workspace/` is laid out flat (no `.ai/strikethroo/` wrapper) so it is **not** directly servable — copy its `plans/`+`archive/` into an initialized workspace to demo real data.
-- **e2e self-installs its browser.** `npm run test:e2e` runs `pretest:e2e` (`playwright install --with-deps chromium`) first; unit (190) and e2e (36) suites pass green here.
-- Hot-reloading dev viewer: `npm run dev:serve` (ts-node, `--no-open`).
+When developing in a Cursor Cloud Agent VM, read [`.cursor/cloud-instructions.md`](.cursor/cloud-instructions.md) for environment setup and run caveats (build-before-run, the `serve` workspace requirement, e2e browser install). Load it on demand — it is not needed for routine local work.
 
 <!-- >>> kenkeep:kk-index >>> -->
 Curated project knowledge lives in [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md), the entry catalog of the knowledge base. Enter there and descend before designing a non-trivial change:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,15 @@ Custom error classes (`src/types.ts`): `FileSystemError`, `ConfigError`, `Templa
 
 ---
 
+## Cursor Cloud specific instructions
+
+Dependencies are installed automatically on VM startup (`npm install`). Node 22+ is present.
+
+- **Build before running the CLI or `serve`.** `npm install` only runs `husky`. Run `npm run build` (see `## Build Pipeline`) to produce `dist/` + `dist-web/` before `node dist/cli.js …`. `npm run test:unit` and `npm run lint` run against `src/` and need no build.
+- **`serve` requires an initialized workspace.** It resolves `<project>/.ai/strikethroo/.init-metadata.json` (walks upward from cwd, or use `--workspace <projectDir>`). To get content to view: `node dist/cli.js init --harnesses claude --destination-directory <dir> --force`, then `node dist/cli.js serve --no-open --port 4317 --workspace <dir>`. The fixture workspace at `src/capture/fixtures/capture-workspace/` is laid out flat (no `.ai/strikethroo/` wrapper) so it is **not** directly servable — copy its `plans/`+`archive/` into an initialized workspace to demo real data.
+- **e2e self-installs its browser.** `npm run test:e2e` runs `pretest:e2e` (`playwright install --with-deps chromium`) first; unit (190) and e2e (36) suites pass green here.
+- Hot-reloading dev viewer: `npm run dev:serve` (ts-node, `--no-open`).
+
 <!-- >>> kenkeep:kk-index >>> -->
 Curated project knowledge lives in [.ai/kenkeep/ENTRY.md](.ai/kenkeep/ENTRY.md), the entry catalog of the knowledge base. Enter there and descend before designing a non-trivial change:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the non-obvious setup/run details for developing this repo in a Cursor Cloud Agent VM. The detail lives in a standalone **`.cursor/cloud-instructions.md`** and `AGENTS.md` carries a short on-demand pointer (loaded only when relevant, not inline). The file is force-added because the repo gitignores `.cursor/`.

Captured guidance:
- `npm install` only runs `husky`; `npm run build` (producing `dist/` + `dist-web/`) is required before `node dist/cli.js …`. Unit tests and lint run against `src/` and need no build.
- `serve` requires an initialized workspace (`<project>/.ai/strikethroo/.init-metadata.json`); use `--workspace <dir>`. The flat fixture workspace under `src/capture/fixtures/capture-workspace/` is not directly servable — copy its `plans/`+`archive/` into an initialized workspace to demo real data.
- `npm run test:e2e` self-installs Chromium via its `pretest:e2e` hook.

## Verification

All run from a fresh install in the Cloud VM:
- `npm run lint` — pass
- `npm run test:unit` — 190 tests pass
- `npm run test:e2e` — 36 tests pass
- `npm run build` + `node dist/cli.js serve` — hosted the read-only workspace SPA and confirmed it renders real plan data (Plans board, Plan Detail, Tasks swimlanes, Graph) end to end in a browser.

No source code changes; docs only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63bb6dce-6c5d-46f9-8c79-53a165d64ac7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63bb6dce-6c5d-46f9-8c79-53a165d64ac7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

