### PR TITLE
docs: update documentation domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@
 </p>
 
 <p align="center">
-  <a href="https://mateuaguilo.com/strikethroo/workflow.html">Workflow</a> &nbsp;·&nbsp;
-  <a href="https://mateuaguilo.com/strikethroo/customization.html">Customization</a> &nbsp;·&nbsp;
-  <a href="https://mateuaguilo.com/strikethroo/visualizations.html">Visualizations</a> &nbsp;·&nbsp;
-  <a href="https://mateuaguilo.com/strikethroo/faq.html">FAQ</a>
+  <a href="https://strikethroo.canpicasoft.com/workflow.html">Workflow</a> &nbsp;·&nbsp;
+  <a href="https://strikethroo.canpicasoft.com/customization.html">Customization</a> &nbsp;·&nbsp;
+  <a href="https://strikethroo.canpicasoft.com/visualizations.html">Visualizations</a> &nbsp;·&nbsp;
+  <a href="https://strikethroo.canpicasoft.com/faq.html">FAQ</a>
 </p>
 
 ## Why Strikethroo?
@@ -85,7 +85,7 @@ Define the shape of plans and tasks -- add your own sections and checklists.
 
 One file of domain knowledge every step reads.
 
-Hooks, templates, and a project-context file are all plain Markdown -- nothing to compile, no plugin API to learn. See the [Customization Guide](https://mateuaguilo.com/strikethroo/customization.html) for examples.
+Hooks, templates, and a project-context file are all plain Markdown -- nothing to compile, no plugin API to learn. See the [Customization Guide](https://strikethroo.canpicasoft.com/customization.html) for examples.
 
 ## Quick Start
 
@@ -124,7 +124,7 @@ Three steps, each delivered as an Agent Skill that loads when you describe what 
 
 Human review gates between steps catch scope creep before any code is written. Each step runs with clean context -- the planning agent sees only the work order, the task agent sees only the approved plan, and each execution sub-agent receives only its specific task.
 
-See the [Workflow Guide](https://mateuaguilo.com/strikethroo/workflow.html) for the full step-by-step with advanced patterns. Once a plan exists, visualize its plans, tasks, and dependency graph in [Visualizations](https://mateuaguilo.com/strikethroo/visualizations.html).
+See the [Workflow Guide](https://strikethroo.canpicasoft.com/workflow.html) for the full step-by-step with advanced patterns. Once a plan exists, visualize its plans, tasks, and dependency graph in [Visualizations](https://strikethroo.canpicasoft.com/visualizations.html).
 
 ## Visualize the data
 Strikethroo comes with an optional **web application** to help you visualize your plans, tasks, and progress. No installation necessary, just execute the following command in a project using Strikethroo:
@@ -141,9 +141,9 @@ This will open a web page that will help you navigate your plans and their tasks
 
 ## Documentation
 
-- [Workflow Guide](https://mateuaguilo.com/strikethroo/workflow.html) -- Step-by-step workflow with visual guides
-- [Customization Guide](https://mateuaguilo.com/strikethroo/customization.html) -- Hooks, templates, and project context
-- [Reference](https://mateuaguilo.com/strikethroo/reference.html) -- Glossary and CLI reference
-- [FAQ](https://mateuaguilo.com/strikethroo/faq.html) -- Answers to common questions
-- [Visualizations](https://mateuaguilo.com/strikethroo/visualizations.html) -- See plans, tasks, and the dependency graph
-- [Migrating from 1.x](https://mateuaguilo.com/strikethroo/migration.html) -- Upgrade from slash commands to Agent Skills
+- [Workflow Guide](https://strikethroo.canpicasoft.com/workflow.html) -- Step-by-step workflow with visual guides
+- [Customization Guide](https://strikethroo.canpicasoft.com/customization.html) -- Hooks, templates, and project context
+- [Reference](https://strikethroo.canpicasoft.com/reference.html) -- Glossary and CLI reference
+- [FAQ](https://strikethroo.canpicasoft.com/faq.html) -- Answers to common questions
+- [Visualizations](https://strikethroo.canpicasoft.com/visualizations.html) -- See plans, tasks, and the dependency graph
+- [Migrating from 1.x](https://strikethroo.canpicasoft.com/migration.html) -- Upgrade from slash commands to Agent Skills

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+strikethroo.canpicasoft.com

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 title: Strikethroo
 description: Structured AI task management with plain text files and Agent Skills
-url: https://mateuaguilo.com
-baseurl: "/strikethroo"
+url: https://strikethroo.canpicasoft.com
+baseurl: ""
 
 # Just the Docs theme configuration
 remote_theme: just-the-docs/just-the-docs

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ export async function init(options: InitOptions): Promise<CommandResult> {
     );
 
     // Add documentation link
-    console.log(`\n  📚 Documentation: ${chalk.cyan('https://mateuaguilo.com/strikethroo')}\n`);
+    console.log(`\n  📚 Documentation: ${chalk.cyan('https://strikethroo.canpicasoft.com')}\n`);
 
     // Show suggested workflow help text
     await displayWorkflowHelp();

--- a/templates/strikethroo/README.md
+++ b/templates/strikethroo/README.md
@@ -4,4 +4,4 @@ This directory contains AI-assisted task management files for this project.
 
 Managed by the [Strikethroo](https://www.github.com/e0ipso/strikethroo) project.
 
-**Documentation**: https://mateuaguilo.com/strikethroo
+**Documentation**: https://strikethroo.canpicasoft.com


### PR DESCRIPTION
## Summary
- set the Jekyll docs canonical URL to strikethroo.canpicasoft.com
- make the docs site build at the subdomain root with an empty Jekyll baseurl
- add docs/CNAME for the GitHub Pages custom subdomain
- update public documentation links and init output to the subdomain

## Verification
- npx tsc --noEmit
- npx eslint src/index.ts
- curl -I https://strikethroo.canpicasoft.com/ returns HTTP/2 200

## Notes
- GitHub Pages for e0ipso/strikethroo is configured with cname=strikethroo.canpicasoft.com.
- e0ipso/e0ipso.github.io remains configured for mateuaguilo.com.