### PR TITLE
docs: remove Pages CNAME artifact

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-strikethroo.canpicasoft.com


### PR DESCRIPTION
## Summary
- remove docs/CNAME from the Actions-built Pages artifact
- keep the custom subdomain managed by the repository Pages setting

## Why
- PR #43 merged the correct root-subdomain Jekyll config, but the Pages deployment failed at actions/deploy-pages.
- The failed artifact already has correct root-relative assets and strikethroo.canpicasoft.com canonical URLs.
- The repo Pages setting already reports cname=strikethroo.canpicasoft.com and protected_domain_state=verified, so the CNAME artifact is redundant for this Actions deployment.

## Verification
- npm test
- inspected the failed Pages artifact from run 28669045318: generated HTML uses /assets/... and https://strikethroo.canpicasoft.com/...
- gh api repos/e0ipso/strikethroo/pages reports cname=strikethroo.canpicasoft.com and protected_domain_state=verified