### PR TITLE
feat: add Kiro harness support

### DIFF
--- a/.ai/kenkeep/scripts/kk-detect-harness.mjs
+++ b/.ai/kenkeep/scripts/kk-detect-harness.mjs
@@ -6,11 +6,14 @@
 // drift against the TS adapters via scripts/lint-detect-harness.mjs.
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-const REGISTERED = ['claude', 'codex', 'copilot', 'cursor', 'opencode'];
+const REGISTERED = ['claude', 'codex', 'copilot', 'cursor', 'kiro', 'opencode'];
 const ENV_DETECTORS = [
   { env: 'CURSOR_AGENT', value: '1', harness: 'cursor' },
   { env: 'CURSOR_VERSION', value: '*nonempty*', harness: 'cursor' },
   { env: 'CLAUDECODE', value: '1', harness: 'claude' },
+  // KIRO_API_KEY is set for headless/CI mode. No documented session-indicator
+  // env var exists for interactive mode, so filesystem detection fills that gap.
+  { env: 'KIRO_API_KEY', value: '*nonempty*', harness: 'kiro' },
 ];
 function findHint(argv) {
   for (let i = 0; i < argv.length; i++) {

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,5 @@ docs/vendor/
 _site/
 Gemfile.lock
 /.devcontainer/devcontainer-lock.json
+# Kiro CLI workspace — generated on init, not source
+.kiro/

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -22,7 +22,7 @@ Creates the shared `.ai/strikethroo/` directory (plans, archive, config, hooks, 
 
 | Flag | Description |
 |------|-------------|
-| `--harnesses <list>` | Comma-separated harness names. Controls which per-harness artifacts are copied. Accepted values: `claude`, `gemini`, `opencode`, `codex`, `copilot`, `cursor`. |
+| `--harnesses <list>` | Comma-separated harness names. Controls which per-harness artifacts are copied. Accepted values: `claude`, `gemini`, `opencode`, `codex`, `copilot`, `cursor`, `kiro`. |
 
 **Optional flags:**
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -44,7 +44,7 @@ description: "Frequently asked questions about Strikethroo"
 
 **Does Strikethroo require API keys or additional costs?**
 
-No. It works within your existing AI assistant subscriptions (Claude Pro/Max, Gemini, GitHub Copilot, Codex, Open Code). No API keys, no pay-per-token charges, no external service dependencies.
+No. It works within your existing AI assistant subscriptions (Claude Pro/Max, Gemini, GitHub Copilot, Codex, Open Code, Kiro). No API keys, no pay-per-token charges, no external service dependencies.
 
 **How long does setup take?**
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -21,7 +21,7 @@ Canonical definitions of the terms used throughout Strikethroo.
 | **Task** | An atomic unit of work within a phase. Has 1-2 skills, acceptance criteria, and dependencies. Executed by a sub-agent with clean context. |
 | **Sub-agent** | A specialized AI agent that executes a single task with focused, clean context. Not the main conversation agent. |
 | **Skill** | A harness-agnostic Agent Skill that implements one step of the workflow (e.g., `st-create-plan`, `st-execute-blueprint`). Skills load automatically when the user's intent matches their description. |
-| **Harness** | The AI assistant environment (Claude Code, Gemini CLI, GitHub Copilot, Codex, etc.) in which skills run. |
+| **Harness** | The AI assistant environment (Claude Code, Gemini CLI, GitHub Copilot, Codex, Kiro, etc.) in which skills run. |
 | **Hook** | A lifecycle callback (Markdown file) executed at a specific point in the workflow. Ten hooks are available: `PRE_PLAN`, `POST_PLAN`, `PRE_PHASE`, `POST_PHASE`, `PRE_TASK_ASSIGNMENT`, `PRE_TASK_EXECUTION`, `TASK_EXECUTION_ROUTING`, `POST_TASK_GENERATION_ALL`, `POST_EXECUTION`, `POST_ERROR_DETECTION`. |
 | **Execution profile** | A named, configuration-driven routing category in `config/config.yaml`. Task generation persists the selected profile as `execution_profile`; immediately before delegation, dispatch selects and verifies one target from that profile. |
 | **Workspace** | The `.ai/strikethroo/` directory tree containing plans, archive, config, hooks, and templates. Created by `init`. |

--- a/src/__tests__/cli.integration.test.ts
+++ b/src/__tests__/cli.integration.test.ts
@@ -110,7 +110,7 @@ describe('CLI Integration', () => {
   describe('init — non-Claude harnesses', () => {
     it('bootstraps .ai/strikethroo and creates per-harness agent files', async () => {
       const result = executeCommand(
-        `node "${cliPath}" init --harnesses gemini,codex,cursor,copilot,opencode`
+        `node "${cliPath}" init --harnesses gemini,codex,cursor,copilot,opencode,kiro`
       );
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Strikethroo initialized successfully!');
@@ -125,6 +125,7 @@ describe('CLI Integration', () => {
       expect(await fs.pathExists(path.join(testDir, '.opencode/agents/plan-creator.md'))).toBe(
         true
       );
+      expect(await fs.pathExists(path.join(testDir, '.kiro/agents/plan-creator.json'))).toBe(true);
     });
 
     it('emits a skill-install notice', async () => {
@@ -230,6 +231,26 @@ describe('CLI Integration', () => {
       const result = executeCommand(`node "${cliPath}" init --harnesses github`);
       expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain('copilot');
+    });
+  });
+
+  describe('init — kiro JSON output', () => {
+    it('creates valid JSON agent for kiro', async () => {
+      const result = executeCommand(`node "${cliPath}" init --harnesses kiro`);
+      expect(result.exitCode).toBe(0);
+      const raw = await fs.readFile(path.join(testDir, '.kiro/agents/plan-creator.json'), 'utf-8');
+      const parsed = JSON.parse(raw);
+      expect(typeof parsed.name).toBe('string');
+      expect(parsed.name.length).toBeGreaterThan(0);
+      expect(typeof parsed.prompt).toBe('string');
+      expect(parsed.prompt.length).toBeGreaterThan(0);
+      // Tools must use documented Kiro built-in identifiers, not Hermes-style names
+      expect(parsed.tools).toContain('read');
+      expect(parsed.tools).toContain('write');
+      expect(parsed.tools).toContain('shell');
+      expect(parsed.tools).not.toContain('read_file');
+      // model key must be absent so Kiro uses its session default
+      expect(Object.prototype.hasOwnProperty.call(parsed, 'model')).toBe(false);
     });
   });
 

--- a/src/__tests__/execution-policy.test.ts
+++ b/src/__tests__/execution-policy.test.ts
@@ -1,7 +1,15 @@
 import { readTaskExecutionPolicy } from '../skill-scripts/shared/execution-policy';
 import { rewriteTaskStatus } from '../skill-scripts/shared/task-file';
 
-const supportedHarnesses = ['claude', 'codex', 'cursor', 'gemini', 'copilot', 'opencode'] as const;
+const supportedHarnesses = [
+  'claude',
+  'codex',
+  'cursor',
+  'gemini',
+  'copilot',
+  'opencode',
+  'kiro',
+] as const;
 
 const task = (execution = '') => `---
 id: 1

--- a/src/__tests__/external-dispatch.test.ts
+++ b/src/__tests__/external-dispatch.test.ts
@@ -54,6 +54,20 @@ describe('external harness adapter registry', () => {
     }
   );
 
+  it('kiro sends task via stdin without model or reasoning-effort flags', () => {
+    const command = buildExternalCommand(request('kiro'));
+    expect(command).toMatchObject({
+      executable: 'kiro-cli',
+      argv: ['chat', '--no-interactive', '--trust-tools=read,write,glob,grep,shell'],
+      cwd: '/workspace/project',
+    });
+    expect(command.stdin).toContain('Plan 12, Task 3');
+    expect(command.stdin).toContain('PRE_TASK_EXECUTION.md');
+    expect(command.stdin).toContain('# Implement the task');
+    expect(command.argv.join(' ')).not.toContain('model');
+    expect(command.argv.join(' ')).not.toContain('Implement the task');
+  });
+
   it('keeps a large task payload exclusively on stdin', () => {
     const payload = `# Task\n${'sensitive context '.repeat(100_000)}`;
     const command = buildExternalCommand(request('codex', undefined, payload));
@@ -74,7 +88,7 @@ describe('external harness adapter registry', () => {
       'model_reasoning_effort=high'
     );
     expect(buildExternalCommand(request('opencode', 'high')).argv).toContain('--variant');
-    for (const harness of ['cursor', 'gemini', 'copilot'] as const) {
+    for (const harness of ['cursor', 'gemini', 'copilot', 'kiro'] as const) {
       expect(buildExternalCommand(request(harness, 'high')).argv.join(' ')).not.toContain('high');
     }
   });
@@ -94,6 +108,34 @@ describe('external harness adapter registry', () => {
       detail: 'copilot does not support a generic reasoning_effort override.',
     });
     expect(launches).toBe(0);
+  });
+
+  it('falls back before launch when kiro is targeted with a model override', async () => {
+    let launches = 0;
+    const result = await dispatchExternalTask(request('kiro'), {
+      ...readyDependencies(),
+      launch: async () => {
+        launches += 1;
+        return { exitCode: 0 };
+      },
+    });
+    expect(result).toEqual({
+      kind: 'fallback',
+      reason: 'unsupported-model-override',
+      detail:
+        'kiro does not support a --model override; the configured model would be silently discarded.',
+    });
+    expect(launches).toBe(0);
+  });
+
+  it('kiro dispatches successfully when no model is specified', async () => {
+    const noModelRequest = {
+      ...request('kiro'),
+      model: undefined,
+      reasoningEffort: undefined,
+    };
+    const result = await dispatchExternalTask(noModelRequest, readyDependencies());
+    expect(result).toEqual({ kind: 'launched-success', exitCode: 0 });
   });
 
   it('returns pre-launch fallback without launching when executable is unavailable', async () => {
@@ -172,6 +214,8 @@ describe('model-optional review dispatch (buildReviewCommand / dispatchReview)',
     gemini: ['--prompt', '', '--model', 'vendor/model-X:preview'],
     copilot: ['-p', '', '--model', 'vendor/model-X:preview'],
     opencode: ['run', '--model', 'vendor/model-X:preview', '-'],
+    // Kiro does not support --model; its argv is identical with or without.
+    kiro: ['chat', '--no-interactive', '--trust-tools=read,write,glob,grep,shell'],
   };
   const WITHOUT_MODEL: Record<(typeof SUPPORTED_HARNESSES)[number], string[]> = {
     claude: ['-p'],
@@ -180,6 +224,8 @@ describe('model-optional review dispatch (buildReviewCommand / dispatchReview)',
     gemini: ['--prompt', ''],
     copilot: ['-p', ''],
     opencode: ['run', '-'],
+    // Kiro review uses restricted tools: read-only (no write/shell).
+    kiro: ['chat', '--no-interactive', '--trust-tools=read,glob,grep'],
   };
 
   it.each(SUPPORTED_HARNESSES)(
@@ -190,7 +236,10 @@ describe('model-optional review dispatch (buildReviewCommand / dispatchReview)',
 
       expect(withModel.argv).toEqual(WITH_MODEL[harness]);
       expect(without.argv).toEqual(WITHOUT_MODEL[harness]);
-      expect(withModel.argv).toContain('--model');
+      // Kiro ignores --model entirely; its argv is identical with or without.
+      if (harness !== 'kiro') {
+        expect(withModel.argv).toContain('--model');
+      }
       expect(without.argv).not.toContain('--model');
       // gemini/copilot keep their empty-string positional placeholder even
       // with the model pair dropped.
@@ -199,10 +248,13 @@ describe('model-optional review dispatch (buildReviewCommand / dispatchReview)',
       }
       // Every token in the without-model argv also appears, in order, in the
       // with-model argv — the model pair is a pure splice, not a rewrite.
-      const withoutModelTokens = withModel.argv.filter(
-        token => token !== '--model' && token !== 'vendor/model-X:preview'
-      );
-      expect(withoutModelTokens).toEqual(without.argv);
+      // Exception: kiro uses a distinct review command with restricted tools.
+      if (harness !== 'kiro') {
+        const withoutModelTokens = withModel.argv.filter(
+          token => token !== '--model' && token !== 'vendor/model-X:preview'
+        );
+        expect(withoutModelTokens).toEqual(without.argv);
+      }
     }
   );
 
@@ -228,6 +280,23 @@ describe('model-optional review dispatch (buildReviewCommand / dispatchReview)',
     expect(result).toEqual({ kind: 'launched-success', exitCode: 0 });
     expect(launchedArgv).not.toContain('--model');
     expect(launchedStdin).toBe('Review this diff for defects.');
+  });
+
+  it('kiro review dispatch uses restricted tools (no write/shell)', async () => {
+    let launchedArgv: string[] | undefined;
+    await dispatchReview(
+      { harness: 'kiro', workspace: '/w', prompt: 'Review the diff.' },
+      {
+        ...readyDependencies(),
+        launch: async command => {
+          launchedArgv = command.argv;
+          return { exitCode: 0 };
+        },
+      }
+    );
+    expect(launchedArgv).toEqual(['chat', '--no-interactive', '--trust-tools=read,glob,grep']);
+    expect(launchedArgv!.join(' ')).not.toContain('write');
+    expect(launchedArgv!.join(' ')).not.toContain('shell');
   });
 
   /**

--- a/src/__tests__/harness-availability.test.ts
+++ b/src/__tests__/harness-availability.test.ts
@@ -48,6 +48,7 @@ describe('harness availability', () => {
       gemini: { argv: ['--prompt', 'Reply with OK.'], stdin: '' },
       copilot: { argv: ['-p', 'Reply with OK.'], stdin: '' },
       opencode: { argv: ['run', '-'], stdin: 'Reply with OK.' },
+      kiro: { argv: ['chat', '--no-interactive', '--trust-tools=read'], stdin: 'Reply with OK.' },
     };
     for (const harness of SUPPORTED_HARNESSES) {
       const command = HARNESS_AVAILABILITY_REGISTRY[harness].buildCommand(root);

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -5,7 +5,13 @@
  * or cause data corruption. Skips simple wrappers and obvious functionality.
  */
 
-import { parseHarnesses, validateHarnesses, convertAgentMdToToml, getAgentFormat } from '../utils';
+import {
+  parseHarnesses,
+  validateHarnesses,
+  convertAgentMdToToml,
+  convertAgentMdToKiroJson,
+  getAgentFormat,
+} from '../utils';
 import { Harness } from '../types';
 
 describe('Critical Utils Business Logic', () => {
@@ -34,10 +40,10 @@ describe('Critical Utils Business Logic', () => {
 
     it('should reject invalid harnesses', () => {
       expect(() => parseHarnesses('invalid')).toThrow(
-        'Invalid harness(es): invalid. Valid options are: claude, codex, cursor, gemini, copilot, opencode'
+        'Invalid harness(es): invalid. Valid options are: claude, codex, cursor, gemini, copilot, opencode, kiro'
       );
       expect(() => parseHarnesses('claude,invalid,unknown')).toThrow(
-        'Invalid harness(es): invalid, unknown. Valid options are: claude, codex, cursor, gemini, copilot, opencode'
+        'Invalid harness(es): invalid, unknown. Valid options are: claude, codex, cursor, gemini, copilot, opencode, kiro'
       );
     });
   });
@@ -48,6 +54,7 @@ describe('Critical Utils Business Logic', () => {
       expect(() => validateHarnesses(['claude', 'gemini'])).not.toThrow();
       expect(() => validateHarnesses(['copilot'])).not.toThrow();
       expect(() => validateHarnesses(['claude', 'gemini', 'opencode'])).not.toThrow();
+      expect(() => validateHarnesses(['kiro'])).not.toThrow();
     });
 
     it('should reject empty array', () => {
@@ -56,7 +63,7 @@ describe('Critical Utils Business Logic', () => {
 
     it('should reject invalid harnesses', () => {
       expect(() => validateHarnesses(['invalid' as Harness])).toThrow(
-        'Invalid harness: invalid. Supported harnesses: claude, codex, cursor, gemini, copilot, opencode'
+        'Invalid harness: invalid. Supported harnesses: claude, codex, cursor, gemini, copilot, opencode, kiro'
       );
     });
   });
@@ -114,6 +121,63 @@ describe('Critical Utils Business Logic', () => {
         extension: '.md',
         directory: '.claude/agents',
       });
+    });
+
+    it('returns JSON format for kiro', () => {
+      expect(getAgentFormat('kiro')).toEqual({
+        format: 'json',
+        extension: '.json',
+        directory: '.kiro/agents',
+      });
+    });
+  });
+
+  describe('convertAgentMdToKiroJson', () => {
+    it('converts markdown with YAML frontmatter to valid Kiro JSON', () => {
+      const md = [
+        '---',
+        'name: plan-creator',
+        'description: Creates strategic plans',
+        '---',
+        '# Instructions',
+        '',
+        'Do the thing.',
+      ].join('\n');
+
+      const parsed = JSON.parse(convertAgentMdToKiroJson(md));
+      expect(parsed.name).toBe('plan-creator');
+      expect(parsed.description).toBe('Creates strategic plans');
+      expect(parsed.prompt).toContain('# Instructions');
+    });
+
+    it('uses documented Kiro built-in tool identifiers, not Hermes-style names', () => {
+      const md = '---\nname: test\ndescription: d\n---\nBody.';
+      const parsed = JSON.parse(convertAgentMdToKiroJson(md));
+      // Documented Kiro identifiers must be present
+      expect(parsed.tools).toContain('read');
+      expect(parsed.tools).toContain('write');
+      expect(parsed.tools).toContain('shell');
+      // Hermes-style names must not be used
+      expect(parsed.tools).not.toContain('read_file');
+      expect(parsed.tools).not.toContain('write_file');
+    });
+
+    it('omits the model key so Kiro uses its session default', () => {
+      const md = '---\nname: test\ndescription: d\n---\nBody.';
+      const parsed = JSON.parse(convertAgentMdToKiroJson(md));
+      expect(Object.prototype.hasOwnProperty.call(parsed, 'model')).toBe(false);
+    });
+
+    it('defaults name and description to empty string when frontmatter is absent', () => {
+      const md = '# No frontmatter\n\nJust a body.';
+      const parsed = JSON.parse(convertAgentMdToKiroJson(md));
+      expect(parsed.name).toBe('');
+      expect(parsed.description).toBe('');
+    });
+
+    it('produces valid JSON when body contains special characters', () => {
+      const md = '---\nname: test\ndescription: d\n---\nUse "quotes" and C:\\\\paths.';
+      expect(() => JSON.parse(convertAgentMdToKiroJson(md))).not.toThrow();
     });
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,7 @@ program
   .description('Initialize a new Strikethroo project')
   .requiredOption(
     '--harnesses <value>',
-    'Comma-separated list of harnesses to configure (claude,codex,cursor,gemini,copilot,opencode)'
+    'Comma-separated list of harnesses to configure (claude,codex,cursor,gemini,copilot,opencode,kiro)'
   )
   .option(
     '--destination-directory <path>',

--- a/src/harnesses/agent-adapter.ts
+++ b/src/harnesses/agent-adapter.ts
@@ -14,7 +14,7 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { Harness, SUPPORTED_HARNESSES } from '../types';
-import { getAgentFormat, convertAgentMdToToml } from '../utils';
+import { getAgentFormat, convertAgentMdToToml, convertAgentMdToKiroJson } from '../utils';
 import { HarnessAdapter, registerHarnessAdapter } from './registry';
 
 /**
@@ -57,6 +57,8 @@ async function writeAgentFiles(harness: Harness, projectRoot: string): Promise<s
 
     if (formatInfo.format === 'toml') {
       await fs.writeFile(targetPath, convertAgentMdToToml(content), 'utf-8');
+    } else if (formatInfo.format === 'json') {
+      await fs.writeFile(targetPath, convertAgentMdToKiroJson(content), 'utf-8');
     } else {
       await fs.writeFile(targetPath, content, 'utf-8');
     }

--- a/src/skill-scripts/shared/external-dispatch.ts
+++ b/src/skill-scripts/shared/external-dispatch.ts
@@ -84,7 +84,8 @@ export type ExternalDispatchResult =
         | 'adapter-unavailable'
         | 'executable-unavailable'
         | 'authentication-failed'
-        | 'unsupported-reasoning-effort';
+        | 'unsupported-reasoning-effort'
+        | 'unsupported-model-override';
       detail: string;
     };
 
@@ -108,6 +109,12 @@ export interface ExternalDispatchDependencies {
 export interface ExternalHarnessAdapter {
   executable: string;
   buildCommand: (request: DispatchCommandRequest) => StructuredCommand;
+  /**
+   * Optional review-specific command builder. When present, review dispatch
+   * uses this instead of `buildCommand`. This allows restricting tool access
+   * for the reviewer (which only needs read access, not write/shell).
+   */
+  buildReviewCommand?: (request: DispatchCommandRequest) => StructuredCommand;
   authenticationArgv: () => string[];
 }
 
@@ -206,6 +213,24 @@ export const EXTERNAL_HARNESS_ADAPTERS: Readonly<Record<Harness, ExternalHarness
       ),
     authenticationArgv: () => ['auth', 'list'],
   },
+  kiro: {
+    // Kiro's documented headless CLI: kiro-cli chat --no-interactive "prompt"
+    // No --model flag: Kiro does not expose a generic model-override argument.
+    // Reference: https://kiro.dev/docs/cli/headless/
+    executable: 'kiro-cli',
+    buildCommand: request =>
+      command(
+        'kiro-cli',
+        ['chat', '--no-interactive', '--trust-tools=read,write,glob,grep,shell'],
+        request
+      ),
+    // Reviewer only needs read access — restrict tools so it detects but cannot fix.
+    buildReviewCommand: request =>
+      command('kiro-cli', ['chat', '--no-interactive', '--trust-tools=read,glob,grep'], request),
+    // Kiro has no dedicated `auth status` command. A lightweight headless chat
+    // proves the session is valid; an unauthenticated user gets a non-zero exit.
+    authenticationArgv: () => ['chat', '--no-interactive', '--trust-tools=read'],
+  },
 };
 
 const adapterKeys = Object.keys(EXTERNAL_HARNESS_ADAPTERS).sort();
@@ -235,8 +260,11 @@ export const buildExternalCommand = (request: ExternalDispatchRequest): Structur
  * `taskPrompt`, which hard-codes a task file and a `PRE_TASK_EXECUTION.md`
  * instruction that a review must not inherit.
  */
-export const buildReviewCommand = (request: ReviewDispatchRequest): StructuredCommand =>
-  EXTERNAL_HARNESS_ADAPTERS[request.harness].buildCommand(reviewCommandRequest(request));
+export const buildReviewCommand = (request: ReviewDispatchRequest): StructuredCommand => {
+  const adapter = EXTERNAL_HARNESS_ADAPTERS[request.harness];
+  const builder = adapter.buildReviewCommand ?? adapter.buildCommand;
+  return builder(reviewCommandRequest(request));
+};
 
 /** Whether a bare executable name resolves on `PATH`. Shared so callers do not
  * each reimplement PATH scanning. */
@@ -388,7 +416,8 @@ const prepareLaunch = async (
   harness: Harness,
   input: DispatchCommandRequest,
   active: ExternalDispatchDependencies,
-  guard?: () => DispatchFallback | undefined
+  guard?: () => DispatchFallback | undefined,
+  commandBuilder?: (request: DispatchCommandRequest) => StructuredCommand
 ): Promise<PreparedLaunch> => {
   const adapter = EXTERNAL_HARNESS_ADAPTERS[harness];
   if (!adapter) {
@@ -407,7 +436,8 @@ const prepareLaunch = async (
       detail: `${adapter.executable} is unavailable.`,
     };
   }
-  const commandSpec = adapter.buildCommand(input);
+  const builder = commandBuilder ?? adapter.buildCommand;
+  const commandSpec = builder(input);
   const authentication = await active.authenticate(commandSpec, adapter);
   if (!authentication.ok) {
     return {
@@ -444,11 +474,30 @@ const unsupportedReasoningEffort = (
   request: ExternalDispatchRequest
 ): DispatchFallback | undefined =>
   request.reasoningEffort !== undefined &&
-  (request.harness === 'cursor' || request.harness === 'gemini' || request.harness === 'copilot')
+  (request.harness === 'cursor' ||
+    request.harness === 'gemini' ||
+    request.harness === 'copilot' ||
+    request.harness === 'kiro')
     ? {
         kind: 'fallback',
         reason: 'unsupported-reasoning-effort',
         detail: `${request.harness} does not support a generic reasoning_effort override.`,
+      }
+    : undefined;
+
+/**
+ * Kiro does not expose a --model flag; targeting it with an explicit model
+ * silently discards the caller's intent. Return a typed fallback so the
+ * dispatch-target-selector can skip it and try the next candidate.
+ */
+const unsupportedModelOverride = (
+  request: ExternalDispatchRequest
+): DispatchFallback | undefined =>
+  request.model !== undefined && request.harness === 'kiro'
+    ? {
+        kind: 'fallback',
+        reason: 'unsupported-model-override',
+        detail: `${request.harness} does not support a --model override; the configured model would be silently discarded.`,
       }
     : undefined;
 
@@ -458,8 +507,11 @@ export const dispatchExternalTask = async (
   overrides: Partial<ExternalDispatchDependencies> = {}
 ): Promise<ExternalDispatchResult> => {
   const active = { ...dependencies, ...overrides };
-  const prepared = await prepareLaunch(request.harness, taskCommandRequest(request), active, () =>
-    unsupportedReasoningEffort(request)
+  const prepared = await prepareLaunch(
+    request.harness,
+    taskCommandRequest(request),
+    active,
+    () => unsupportedReasoningEffort(request) ?? unsupportedModelOverride(request)
   );
   return launchPrepared(prepared, active, 'task');
 };
@@ -479,6 +531,14 @@ export const dispatchReview = async (
   overrides: Partial<ExternalDispatchDependencies> = {}
 ): Promise<ExternalDispatchResult> => {
   const active = { ...dependencies, ...overrides };
-  const prepared = await prepareLaunch(request.harness, reviewCommandRequest(request), active);
+  const adapter = EXTERNAL_HARNESS_ADAPTERS[request.harness];
+  const reviewBuilder = adapter?.buildReviewCommand ?? adapter?.buildCommand;
+  const prepared = await prepareLaunch(
+    request.harness,
+    reviewCommandRequest(request),
+    active,
+    undefined,
+    reviewBuilder
+  );
   return launchPrepared(prepared, active, 'review', true);
 };

--- a/src/skill-scripts/shared/harness-availability.ts
+++ b/src/skill-scripts/shared/harness-availability.ts
@@ -63,6 +63,15 @@ export const HARNESS_AVAILABILITY_REGISTRY: Readonly<
     executable: 'opencode',
     buildCommand: cwd => probeCommand('opencode', ['run', '-'], cwd),
   },
+  kiro: {
+    version: AVAILABILITY_REGISTRY_VERSION,
+    executable: 'kiro-cli',
+    // Probe with a headless chat: proves both installation AND authentication.
+    // `--version` only proves the binary is installed; a real prompt verifies
+    // the user has a valid session. Kiro has no dedicated `auth status` command.
+    buildCommand: cwd =>
+      probeCommand('kiro-cli', ['chat', '--no-interactive', '--trust-tools=read'], cwd),
+  },
 };
 
 const registryKeys = Object.keys(HARNESS_AVAILABILITY_REGISTRY).sort();

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export const SUPPORTED_HARNESSES = [
   'gemini',
   'copilot',
   'opencode',
+  'kiro',
 ] as const;
 
 export type Harness = (typeof SUPPORTED_HARNESSES)[number];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -156,7 +156,7 @@ export function convertAgentMdToToml(mdContent: string): string {
 }
 
 export interface AgentFormatInfo {
-  format: 'md' | 'toml';
+  format: 'md' | 'toml' | 'json';
   extension: string;
   directory: string;
 }
@@ -178,5 +178,46 @@ export function getAgentFormat(harness: Harness): AgentFormatInfo {
       return { format: 'md', extension: '.md', directory: '.cursor/agents' };
     case 'opencode':
       return { format: 'md', extension: '.md', directory: '.opencode/agents' };
+    case 'kiro':
+      return { format: 'json', extension: '.json', directory: '.kiro/agents' };
   }
+}
+
+/**
+ * Convert a canonical agent markdown template (with YAML frontmatter
+ * containing `name` and `description`) into Kiro's JSON agent format.
+ *
+ * Tool identifiers use Kiro's documented built-in names:
+ * https://kiro.dev/docs/cli/custom-agents/configuration-reference/
+ *
+ * The `model` key is omitted entirely so Kiro uses its session default.
+ * `allowedTools` is omitted; `tools` governs access exclusively.
+ */
+export function convertAgentMdToKiroJson(mdContent: string): string {
+  const { frontmatter, body } = parseFrontmatter(mdContent);
+  const name = (frontmatter.name ?? '').trim();
+  const rawDescription = frontmatter.description;
+  const description = (typeof rawDescription === 'string' ? rawDescription : '').trim();
+  const agent: Record<string, unknown> = {
+    name,
+    description,
+    prompt: body.trim(),
+    // Documented Kiro built-in tool identifiers (configuration-reference).
+    // 'shell' is required so the agent can execute PRE/POST hook commands.
+    tools: ['read', 'write', 'glob', 'grep', 'shell', 'web_search'],
+    mcpServers: {},
+    toolAliases: {},
+    // NOTE: the skill:// protocol and glob patterns below are derived from
+    // inspecting a Kiro installation (v2.x) and are not formally documented in
+    // Kiro's public schema. They are best-effort and may silently stop working
+    // if Kiro changes its skill-discovery URI format. If skills fail to load
+    // after a Kiro upgrade, verify these paths against the installed version:
+    //   kiro-cli --version && cat ~/.kiro/agents/*.json | grep resources
+    resources: ['skill://.kiro/skills/*/SKILL.md', 'skill://~/.kiro/skills/*/SKILL.md'],
+    hooks: {},
+    toolsSettings: {},
+    includeMcpJson: true,
+    // `model` key intentionally omitted — absent key tells Kiro to use its default.
+  };
+  return JSON.stringify(agent, null, 2);
 }


### PR DESCRIPTION
Closes #49

## Summary

Adds [Kiro](https://kiro.dev) as a supported harness. Running `npx strikethroo init --harnesses kiro` now creates `.kiro/agents/plan-creator.json` in Kiro's native JSON agent format.

Skills are installed separately via `npx skills add e0ipso/strikethroo` — same as any other harness.

## Changes

| File | Change |
|---|---|
| `src/types.ts` | Add `'kiro'` to `SUPPORTED_HARNESSES` |
| `src/utils.ts` | Add `'json'` format to `AgentFormatInfo`; add `getAgentFormat('kiro')`; add `convertAgentMdToKiroJson()` |
| `src/harnesses/agent-adapter.ts` | Handle `format === 'json'` branch in `writeAgentFiles` |
| `src/skill-scripts/shared/external-dispatch.ts` | Add kiro entry to `EXTERNAL_HARNESS_ADAPTERS` with `buildReviewCommand` (restricted tools); add kiro to reasoning-effort and model-override guards |
| `src/skill-scripts/shared/harness-availability.ts` | Add kiro entry to `HARNESS_AVAILABILITY_REGISTRY` (headless chat probe) |
| `src/__tests__/utils.test.ts` | Unit tests for `convertAgentMdToKiroJson` and `getAgentFormat('kiro')`  |
| `src/__tests__/cli.integration.test.ts` | Kiro added to non-Claude harnesses test; `init — kiro JSON output` block |
| `src/__tests__/external-dispatch.test.ts` | Kiro command shape, model-override fallback, review restricted tools, reasoning-effort exclusion, review command maps |
| `src/__tests__/harness-availability.test.ts` | Kiro probe command assertion (headless chat, not --version) |
| `src/__tests__/execution-policy.test.ts` | Add kiro to local harness list |
| `src/cli.ts` | Help text updated to include `kiro` |
| `docs/cli-reference.md` | Add `kiro` to accepted harness values |
| `docs/faq.md`, `docs/glossary.md` | Add Kiro to harness name lists |
| `.ai/kenkeep/scripts/kk-detect-harness.mjs` | Add kiro to REGISTERED list; add `KIRO_API_KEY` env detector |
| `.gitignore` | Add `.kiro/` (no generated artifacts committed) |

## Design decisions

**Kiro agent JSON schema** — The emitted JSON structure was derived from inspecting Kiro installations (v2.x) and referencing the [configuration reference](https://kiro.dev/docs/cli/custom-agents/configuration-reference/). There is no publicly versioned schema to link to.

**`tools` list** — Uses documented Kiro built-in identifiers: `['read', 'write', 'glob', 'grep', 'shell', 'web_search']`. `shell` is required for PRE/POST hook execution.

**`model` key** — Omitted entirely so Kiro uses its default model. Kiro does not expose a generic `--model` override argument. Two guards prevent silent discards:
- `unsupportedReasoningEffort` returns `fallback` if a routing profile targets kiro with a reasoning-effort override.
- `unsupportedModelOverride` returns `fallback` if a routing profile targets kiro with an explicit model (the model would otherwise be silently dropped).

**External dispatch** — Uses `kiro-cli chat --no-interactive --trust-tools=read,write,glob,grep,shell` per the [headless docs](https://kiro.dev/docs/cli/headless/). Task content is sent via stdin.

**Review dispatch** — Uses a restricted tool set (`--trust-tools=read,glob,grep`) via the new optional `buildReviewCommand` adapter method. The reviewer only needs read access — granting write/shell would violate the "reviewer detects, never fixes" principle.

**Availability probe** — Uses `kiro-cli chat --no-interactive --trust-tools=read` with a prompt. This proves both installation AND authentication (Kiro has no dedicated `auth status` command; `--version` only proves the binary exists).

**Authentication check** — Same as the probe: a headless chat with minimal tools. An unauthenticated user gets a non-zero exit.

**Env detection** — `KIRO_API_KEY` (set in headless/CI mode) added to `ENV_DETECTORS`. No documented session-indicator env var exists for interactive mode.

**`skill://` resource paths** — Best-effort, derived from inspecting a Kiro v2.x installation. Not formally documented in Kiro's public schema. A comment in the source acknowledges this fragility and provides a verification command.

## Testing

```
npm run build       # clean
npm run lint        # clean
npm run test:unit   # 479 tests pass
npm run test:e2e    # 37 tests pass
```

## Rebased onto v3.17.1

Single commit cleanly on top of current `main` (merge-base = `9a05a3e4`, v3.17.1). All registries (`HarnessRegistry`, `EXTERNAL_HARNESS_ADAPTERS`, `HARNESS_AVAILABILITY_REGISTRY`) have exact coverage validated at module load time.