### PR TITLE
feat: add task execution overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ skills-lock.json
 # <<< @e0ipso/ai-knowledge-base <<<
 
 # Playwright test artifacts
+/.playwright/
 test-results/
 playwright-report/
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -22,7 +22,7 @@ Creates the shared `.ai/strikethroo/` directory (plans, archive, config, hooks, 
 
 | Flag | Description |
 |------|-------------|
-| `--harnesses <list>` | Comma-separated harness names. Controls which per-harness artifacts are copied. Accepted values: `claude`, `gemini`, `opencode`, `codex`, `github`, `cursor`. |
+| `--harnesses <list>` | Comma-separated harness names. Controls which per-harness artifacts are copied. Accepted values: `claude`, `gemini`, `opencode`, `codex`, `copilot`, `cursor`. |
 
 **Optional flags:**
 

--- a/scripts/build-skill-prompts.cjs
+++ b/scripts/build-skill-prompts.cjs
@@ -305,6 +305,14 @@ function main() {
       );
     }
 
+    // Validate current assembled output, not a stale SKILL.md from a prior build.
+    for (const [, script] of output.matchAll(/scripts\/([\w.-]+\.cjs)/g)) {
+      const scriptPath = path.join(targetDir, 'scripts', script);
+      if (!fs.existsSync(scriptPath)) {
+        throw new Error(`${meta.target}: references missing script scripts/${script}`);
+      }
+    }
+
     const outPath = path.join(targetDir, 'SKILL.md');
     fs.writeFileSync(outPath, output, 'utf8');
     process.stdout.write(`  assembled ${meta.target}/SKILL.md\n`);

--- a/scripts/build-skills.cjs
+++ b/scripts/build-skills.cjs
@@ -69,6 +69,11 @@ const SKILL_ENTRYPOINTS = [
     out: 'check-phase-readiness.cjs',
   },
   {
+    src: 'src/skill-scripts/dispatch-task-execution.ts',
+    skill: 'st-execute-blueprint',
+    out: 'dispatch-task-execution.cjs',
+  },
+  {
     src: 'src/skill-scripts/find-strikethroo-root.ts',
     skill: 'st-refine-plan',
     out: 'find-strikethroo-root.cjs',
@@ -92,6 +97,11 @@ const SKILL_ENTRYPOINTS = [
     src: 'src/skill-scripts/check-task-dependencies.ts',
     skill: 'st-execute-task',
     out: 'check-task-dependencies.cjs',
+  },
+  {
+    src: 'src/skill-scripts/dispatch-task-execution.ts',
+    skill: 'st-execute-task',
+    out: 'dispatch-task-execution.cjs',
   },
   {
     src: 'src/skill-scripts/find-strikethroo-root.ts',

--- a/scripts/build-skills.cjs
+++ b/scripts/build-skills.cjs
@@ -179,21 +179,6 @@ const buildAll = async () => {
       process.exit(1);
     }
   }
-
-  // Every script referenced by an assembled skill must ship beside it. This
-  // catches shared prompt sections added without matching bundle registration.
-  for (const skill of fs.readdirSync(SKILLS_ROOT)) {
-    const skillFile = path.join(SKILLS_ROOT, skill, 'SKILL.md');
-    if (!fs.existsSync(skillFile)) continue;
-    const contents = fs.readFileSync(skillFile, 'utf8');
-    const references = [...contents.matchAll(/scripts\/([\w.-]+\.cjs)/g)];
-    for (const [, script] of references) {
-      const scriptFile = path.join(SKILLS_ROOT, skill, 'scripts', script);
-      if (!fs.existsSync(scriptFile)) {
-        throw new Error(`${skill}/SKILL.md references missing script scripts/${script}`);
-      }
-    }
-  }
 };
 
 buildAll().catch((err) => {

--- a/scripts/build-skills.cjs
+++ b/scripts/build-skills.cjs
@@ -133,6 +133,11 @@ const SKILL_ENTRYPOINTS = [
     skill: 'st-full-workflow',
     out: 'check-phase-readiness.cjs',
   },
+  {
+    src: 'src/skill-scripts/dispatch-task-execution.ts',
+    skill: 'st-full-workflow',
+    out: 'dispatch-task-execution.cjs',
+  },
 ];
 
 const nodeTarget = `node${process.versions.node.split('.')[0]}`;
@@ -172,6 +177,21 @@ const buildAll = async () => {
           'EXPECTED_WORKSPACE_SCHEMA_VERSION (esbuild define did not substitute).'
       );
       process.exit(1);
+    }
+  }
+
+  // Every script referenced by an assembled skill must ship beside it. This
+  // catches shared prompt sections added without matching bundle registration.
+  for (const skill of fs.readdirSync(SKILLS_ROOT)) {
+    const skillFile = path.join(SKILLS_ROOT, skill, 'SKILL.md');
+    if (!fs.existsSync(skillFile)) continue;
+    const contents = fs.readFileSync(skillFile, 'utf8');
+    const references = [...contents.matchAll(/scripts\/([\w.-]+\.cjs)/g)];
+    for (const [, script] of references) {
+      const scriptFile = path.join(SKILLS_ROOT, skill, 'scripts', script);
+      if (!fs.existsSync(scriptFile)) {
+        throw new Error(`${skill}/SKILL.md references missing script scripts/${script}`);
+      }
     }
   }
 };

--- a/src/__tests__/cli.integration.test.ts
+++ b/src/__tests__/cli.integration.test.ts
@@ -102,7 +102,7 @@ describe('CLI Integration', () => {
   describe('init — non-Claude harnesses', () => {
     it('bootstraps .ai/strikethroo and creates per-harness agent files', async () => {
       const result = executeCommand(
-        `node "${cliPath}" init --harnesses gemini,codex,cursor,github,opencode`
+        `node "${cliPath}" init --harnesses gemini,codex,cursor,copilot,opencode`
       );
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Strikethroo initialized successfully!');
@@ -113,9 +113,7 @@ describe('CLI Integration', () => {
       expect(await fs.pathExists(path.join(testDir, '.gemini/agents/plan-creator.md'))).toBe(true);
       expect(await fs.pathExists(path.join(testDir, '.codex/agents/plan-creator.toml'))).toBe(true);
       expect(await fs.pathExists(path.join(testDir, '.cursor/agents/plan-creator.md'))).toBe(true);
-      expect(await fs.pathExists(path.join(testDir, '.github/agents/plan-creator.agent.md'))).toBe(
-        true
-      );
+      expect(await fs.pathExists(path.join(testDir, '.github/agents/plan-creator.md'))).toBe(true);
       expect(await fs.pathExists(path.join(testDir, '.opencode/agents/plan-creator.md'))).toBe(
         true
       );
@@ -213,25 +211,27 @@ describe('CLI Integration', () => {
     });
   });
 
-  describe('init — github .agent.md extension', () => {
-    it('creates .agent.md file for github', async () => {
-      const result = executeCommand(`node "${cliPath}" init --harnesses github`);
+  describe('init — copilot .md extension', () => {
+    it('creates .md file for copilot', async () => {
+      const result = executeCommand(`node "${cliPath}" init --harnesses copilot`);
       expect(result.exitCode).toBe(0);
-      expect(await fs.pathExists(path.join(testDir, '.github/agents/plan-creator.agent.md'))).toBe(
-        true
-      );
+      expect(await fs.pathExists(path.join(testDir, '.github/agents/plan-creator.md'))).toBe(true);
+    });
+
+    it('rejects the replaced github identifier', () => {
+      const result = executeCommand(`node "${cliPath}" init --harnesses github`);
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout + result.stderr).toContain('copilot');
     });
   });
 
   describe('init — multi-harness simultaneous output', () => {
     it('creates agent files for multiple harnesses simultaneously', async () => {
-      const result = executeCommand(`node "${cliPath}" init --harnesses claude,codex,github`);
+      const result = executeCommand(`node "${cliPath}" init --harnesses claude,codex,copilot`);
       expect(result.exitCode).toBe(0);
       expect(await fs.pathExists(path.join(testDir, '.claude/agents/plan-creator.md'))).toBe(true);
       expect(await fs.pathExists(path.join(testDir, '.codex/agents/plan-creator.toml'))).toBe(true);
-      expect(await fs.pathExists(path.join(testDir, '.github/agents/plan-creator.agent.md'))).toBe(
-        true
-      );
+      expect(await fs.pathExists(path.join(testDir, '.github/agents/plan-creator.md'))).toBe(true);
     });
   });
 

--- a/src/__tests__/dispatch-task-execution.integration.test.ts
+++ b/src/__tests__/dispatch-task-execution.integration.test.ts
@@ -1,0 +1,87 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { buildSync } from 'esbuild';
+
+const makeBundle = (directory: string): string => {
+  const outfile = path.join(directory, 'dispatch-task-execution.cjs');
+  buildSync({
+    entryPoints: [path.resolve('src/skill-scripts/dispatch-task-execution.ts')],
+    outfile,
+    platform: 'node',
+    format: 'cjs',
+    bundle: true,
+    target: 'node22',
+    define: { EXPECTED_WORKSPACE_SCHEMA_VERSION: '3' },
+  });
+  return outfile;
+};
+
+const run = (bundle: string, args: string[], env = process.env) =>
+  spawnSync(process.execPath, [bundle, ...args], { encoding: 'utf8', env });
+
+describe('dispatch task execution entrypoint', () => {
+  it('emits one infrastructure JSON line for an unreadable task file', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'st-dispatch-'));
+    const bundle = makeBundle(directory);
+    const result = run(bundle, [path.join(directory, 'missing.md'), 'codex', directory, '12', '3']);
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toBe('');
+    expect(result.stdout.trim().split('\n')).toHaveLength(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      kind: 'infrastructure-failure',
+      detail: expect.stringContaining('ENOENT'),
+    });
+  });
+
+  it('resolves an external route without checking or launching its executable', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'st-dispatch-'));
+    const bundle = makeBundle(directory);
+    const taskFile = path.join(directory, 'task.md');
+    fs.writeFileSync(
+      taskFile,
+      '---\nid: 3\nstatus: pending\nexecution:\n  harness: claude\n  model: exact/model\n---\n# Task\n'
+    );
+    const result = run(bundle, ['resolve', taskFile, 'codex', directory, '12', '3'], {
+      ...process.env,
+      PATH: '',
+    });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      kind: 'external-override',
+      harness: 'claude',
+      model: 'exact/model',
+    });
+  });
+
+  it('emits infrastructure failure when the executable disappears after preflight', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'st-dispatch-'));
+    const bundle = makeBundle(directory);
+    const executable = path.join(directory, 'claude');
+    fs.writeFileSync(
+      executable,
+      '#!/bin/sh\nif [ "$1" = "auth" ]; then rm -- "$0"; exit 0; fi\nexit 0\n',
+      { mode: 0o700 }
+    );
+    const taskFile = path.join(directory, 'task.md');
+    fs.writeFileSync(
+      taskFile,
+      '---\nid: 3\nstatus: pending\nexecution:\n  harness: claude\n  model: exact/model\n---\n# Task\n'
+    );
+    const result = run(bundle, [taskFile, 'codex', directory, '12', '3'], {
+      ...process.env,
+      PATH: `${directory}${path.delimiter}${process.env.PATH ?? ''}`,
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toBe('');
+    expect(result.stdout.trim().split('\n')).toHaveLength(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      kind: 'infrastructure-failure',
+      detail: expect.stringContaining('ENOENT'),
+    });
+  });
+});

--- a/src/__tests__/execution-policy.test.ts
+++ b/src/__tests__/execution-policy.test.ts
@@ -1,0 +1,89 @@
+import { readTaskExecutionPolicy } from '../skill-scripts/shared/execution-policy';
+import { rewriteTaskStatus } from '../skill-scripts/shared/task-file';
+
+const supportedHarnesses = ['claude', 'codex', 'cursor', 'gemini', 'copilot', 'opencode'] as const;
+
+const task = (execution = '') => `---
+id: 1
+status: "pending"
+${execution}---
+# Task
+`;
+
+describe('task execution policy', () => {
+  it('keeps tasks without an execution mapping on the native default path', () => {
+    expect(
+      readTaskExecutionPolicy(task(), { currentHarness: 'codex', supportedHarnesses })
+    ).toEqual({
+      kind: 'native-default',
+    });
+  });
+
+  it('preserves an exact model and optional reasoning effort for a native override', () => {
+    expect(
+      readTaskExecutionPolicy(
+        task('execution:\n  model: "openai/gpt-5.6-terra:preview"\n  reasoning_effort: high\n'),
+        { currentHarness: 'codex', supportedHarnesses }
+      )
+    ).toEqual({
+      kind: 'native-override',
+      model: 'openai/gpt-5.6-terra:preview',
+      reasoningEffort: 'high',
+    });
+  });
+
+  it('returns a valid external override for a different supported harness', () => {
+    expect(
+      readTaskExecutionPolicy(task('execution:\n  model: vendor/model-X\n  harness: copilot\n'), {
+        currentHarness: 'codex',
+        supportedHarnesses,
+      })
+    ).toEqual({ kind: 'external-override', harness: 'copilot', model: 'vendor/model-X' });
+  });
+
+  it.each([
+    ['missing-model', 'execution: {}\n'],
+    ['invalid-model', 'execution:\n  model: 12\n'],
+    ['invalid-reasoning-effort', 'execution:\n  model: exact\n  reasoning_effort: 2\n'],
+    ['unsupported-harness', 'execution:\n  model: exact\n  harness: unknown\n'],
+    ['same-orchestrator-harness', 'execution:\n  model: exact\n  harness: codex\n'],
+  ])('falls back before launch for %s', (reason, execution) => {
+    const result = readTaskExecutionPolicy(task(execution), {
+      currentHarness: 'codex',
+      supportedHarnesses,
+    });
+    expect(result).toMatchObject({ kind: 'fallback', reason });
+    expect(result.detail).toBeTruthy();
+  });
+});
+
+describe('lossless task status rewrite', () => {
+  it('changes only the root frontmatter status and preserves nested execution bytes', () => {
+    const source = `---\r
+id: 1\r
+status: "pending" # lifecycle\r
+execution:\r
+  model: "vendor/model-X"\r
+  reasoning_effort: high\r
+  metadata:\r
+    status: untouched\r
+skills:\r
+  - typescript\r
+---\r
+# Task\r
+\r
+status: body text\r
+`;
+    expect(rewriteTaskStatus(source, 'in-progress')).toBe(
+      source.replace('status: "pending" # lifecycle', 'status: "in-progress" # lifecycle')
+    );
+  });
+
+  it.each([
+    ['# Task\n', 'missing frontmatter'],
+    ['---\nid: 1\n---\n# Task\n', 'missing root status'],
+    ['---\nstatus: pending\nstatus: done\n---\n# Task\n', 'duplicate root status'],
+  ])('rejects a %s document', (source, message) => {
+    expect(() => rewriteTaskStatus(source, 'completed')).toThrow(message);
+  });
+});

--- a/src/__tests__/external-dispatch.test.ts
+++ b/src/__tests__/external-dispatch.test.ts
@@ -6,7 +6,11 @@ import {
   type ExternalDispatchDependencies,
 } from '../skill-scripts/shared/external-dispatch';
 
-const request = (harness: (typeof SUPPORTED_HARNESSES)[number], reasoningEffort?: string) => ({
+const request = (
+  harness: (typeof SUPPORTED_HARNESSES)[number],
+  reasoningEffort?: string,
+  taskMarkdown = '# Implement the task'
+) => ({
   harness,
   model: 'vendor/model-X:preview',
   reasoningEffort,
@@ -14,13 +18,13 @@ const request = (harness: (typeof SUPPORTED_HARNESSES)[number], reasoningEffort?
   planId: '12',
   taskId: '3',
   taskFile: '/workspace/project/.ai/strikethroo/plans/12--example/tasks/03--task.md',
-  taskMarkdown: '# Implement the task',
+  taskMarkdown,
 });
 
 const readyDependencies = (): ExternalDispatchDependencies => ({
   executableExists: () => true,
-  authenticate: () => ({ ok: true }),
-  launch: () => ({ exitCode: 0 }),
+  authenticate: async () => ({ ok: true }),
+  launch: async () => ({ exitCode: 0 }),
 });
 
 describe('external harness adapter registry', () => {
@@ -29,24 +33,31 @@ describe('external harness adapter registry', () => {
   });
 
   it.each([
-    ['claude', 'claude', ['-p', expect.any(String), '--model', 'vendor/model-X:preview']],
-    ['codex', 'codex', ['exec', '--model', 'vendor/model-X:preview', expect.any(String)]],
-    [
-      'cursor',
-      'cursor-agent',
-      ['--print', '--model', 'vendor/model-X:preview', expect.any(String)],
-    ],
-    ['gemini', 'gemini', ['--prompt', expect.any(String), '--model', 'vendor/model-X:preview']],
-    ['copilot', 'copilot', ['-p', expect.any(String), '--model', 'vendor/model-X:preview']],
-    ['opencode', 'opencode', ['run', '--model', 'vendor/model-X:preview', expect.any(String)]],
+    ['claude', 'claude', ['-p', '--model', 'vendor/model-X:preview']],
+    ['codex', 'codex', ['exec', '--model', 'vendor/model-X:preview', '-']],
+    ['cursor', 'cursor-agent', ['--print', '--model', 'vendor/model-X:preview']],
+    ['gemini', 'gemini', ['--prompt', '', '--model', 'vendor/model-X:preview']],
+    ['copilot', 'copilot', ['-p', '', '--model', 'vendor/model-X:preview']],
+    ['opencode', 'opencode', ['run', '--model', 'vendor/model-X:preview', '-']],
   ] as const)(
-    '%s preserves exact model in structured argv',
-    (harness, executable, expectedArgv) => {
+    '%s preserves exact model while keeping task content out of argv',
+    (harness, executable, argv) => {
       const command = buildExternalCommand(request(harness));
-      expect(command).toMatchObject({ executable, argv: expectedArgv, cwd: '/workspace/project' });
-      expect(command.argv.join(' ')).toContain('Plan 12, Task 3');
+      expect(command).toMatchObject({ executable, argv, cwd: '/workspace/project' });
+      expect(command.stdin).toContain('Plan 12, Task 3');
+      expect(command.stdin).toContain('PRE_TASK_EXECUTION.md');
+      expect(command.stdin).toContain('# Implement the task');
+      expect(command.argv.join(' ')).not.toContain('Implement the task');
     }
   );
+
+  it('keeps a large task payload exclusively on stdin', () => {
+    const payload = `# Task\n${'sensitive context '.repeat(100_000)}`;
+    const command = buildExternalCommand(request('codex', undefined, payload));
+    expect(command.stdin).toContain(payload);
+    expect(command.argv.join(' ')).not.toContain('sensitive context');
+    expect(command.argv.join(' ').length).toBeLessThan(200);
+  });
 
   it.each(SUPPORTED_HARNESSES)('omits optional reasoning argv for %s when absent', harness => {
     expect(buildExternalCommand(request(harness)).argv.join(' ')).not.toContain('reasoning_effort');
@@ -65,11 +76,11 @@ describe('external harness adapter registry', () => {
     }
   });
 
-  it('falls back before launch when a harness lacks reasoning-effort support', () => {
+  it('falls back before launch when a harness lacks reasoning-effort support', async () => {
     let launches = 0;
-    const result = dispatchExternalTask(request('copilot', 'high'), {
+    const result = await dispatchExternalTask(request('copilot', 'high'), {
       ...readyDependencies(),
-      launch: () => {
+      launch: async () => {
         launches += 1;
         return { exitCode: 0 };
       },
@@ -82,12 +93,12 @@ describe('external harness adapter registry', () => {
     expect(launches).toBe(0);
   });
 
-  it('returns pre-launch fallback without launching when executable is unavailable', () => {
+  it('returns pre-launch fallback without launching when executable is unavailable', async () => {
     let launches = 0;
-    const result = dispatchExternalTask(request('copilot'), {
+    const result = await dispatchExternalTask(request('copilot'), {
       ...readyDependencies(),
       executableExists: () => false,
-      launch: () => {
+      launch: async () => {
         launches += 1;
         return { exitCode: 0 };
       },
@@ -100,12 +111,12 @@ describe('external harness adapter registry', () => {
     expect(launches).toBe(0);
   });
 
-  it('returns pre-launch fallback without launching when authentication fails', () => {
+  it('returns pre-launch fallback without launching when authentication fails', async () => {
     let launches = 0;
-    const result = dispatchExternalTask(request('codex'), {
+    const result = await dispatchExternalTask(request('codex'), {
       ...readyDependencies(),
-      authenticate: () => ({ ok: false, detail: 'authentication check failed' }),
-      launch: () => {
+      authenticate: async () => ({ ok: false, detail: 'authentication check failed' }),
+      launch: async () => {
         launches += 1;
         return { exitCode: 0 };
       },
@@ -118,16 +129,29 @@ describe('external harness adapter registry', () => {
     expect(launches).toBe(0);
   });
 
-  it('reports a launched nonzero process as failure and never performs a native retry', () => {
+  it('reports a launched nonzero process as failure and never performs a native retry', async () => {
     let launches = 0;
-    const result = dispatchExternalTask(request('gemini'), {
+    const result = await dispatchExternalTask(request('gemini'), {
       ...readyDependencies(),
-      launch: () => {
+      launch: async () => {
         launches += 1;
         return { exitCode: 9 };
       },
     });
     expect(result).toEqual({ kind: 'launched-failure', exitCode: 9 });
     expect(launches).toBe(1);
+  });
+
+  it('converts spawn errors after launch into infrastructure failure', async () => {
+    const result = await dispatchExternalTask(request('claude'), {
+      ...readyDependencies(),
+      launch: async () => {
+        throw new Error('spawn EACCES');
+      },
+    });
+    expect(result).toEqual({
+      kind: 'infrastructure-failure',
+      detail: 'External task process failed: spawn EACCES',
+    });
   });
 });

--- a/src/__tests__/external-dispatch.test.ts
+++ b/src/__tests__/external-dispatch.test.ts
@@ -1,0 +1,133 @@
+import { SUPPORTED_HARNESSES } from '../types';
+import {
+  buildExternalCommand,
+  dispatchExternalTask,
+  EXTERNAL_HARNESS_ADAPTERS,
+  type ExternalDispatchDependencies,
+} from '../skill-scripts/shared/external-dispatch';
+
+const request = (harness: (typeof SUPPORTED_HARNESSES)[number], reasoningEffort?: string) => ({
+  harness,
+  model: 'vendor/model-X:preview',
+  reasoningEffort,
+  workspace: '/workspace/project',
+  planId: '12',
+  taskId: '3',
+  taskFile: '/workspace/project/.ai/strikethroo/plans/12--example/tasks/03--task.md',
+  taskMarkdown: '# Implement the task',
+});
+
+const readyDependencies = (): ExternalDispatchDependencies => ({
+  executableExists: () => true,
+  authenticate: () => ({ ok: true }),
+  launch: () => ({ exitCode: 0 }),
+});
+
+describe('external harness adapter registry', () => {
+  it('covers the canonical supported harnesses exactly', () => {
+    expect(Object.keys(EXTERNAL_HARNESS_ADAPTERS).sort()).toEqual([...SUPPORTED_HARNESSES].sort());
+  });
+
+  it.each([
+    ['claude', 'claude', ['-p', expect.any(String), '--model', 'vendor/model-X:preview']],
+    ['codex', 'codex', ['exec', '--model', 'vendor/model-X:preview', expect.any(String)]],
+    [
+      'cursor',
+      'cursor-agent',
+      ['--print', '--model', 'vendor/model-X:preview', expect.any(String)],
+    ],
+    ['gemini', 'gemini', ['--prompt', expect.any(String), '--model', 'vendor/model-X:preview']],
+    ['copilot', 'copilot', ['-p', expect.any(String), '--model', 'vendor/model-X:preview']],
+    ['opencode', 'opencode', ['run', '--model', 'vendor/model-X:preview', expect.any(String)]],
+  ] as const)(
+    '%s preserves exact model in structured argv',
+    (harness, executable, expectedArgv) => {
+      const command = buildExternalCommand(request(harness));
+      expect(command).toMatchObject({ executable, argv: expectedArgv, cwd: '/workspace/project' });
+      expect(command.argv.join(' ')).toContain('Plan 12, Task 3');
+    }
+  );
+
+  it.each(SUPPORTED_HARNESSES)('omits optional reasoning argv for %s when absent', harness => {
+    expect(buildExternalCommand(request(harness)).argv.join(' ')).not.toContain('reasoning_effort');
+    expect(buildExternalCommand(request(harness)).argv).not.toContain('--effort');
+    expect(buildExternalCommand(request(harness)).argv).not.toContain('--variant');
+  });
+
+  it('uses only documented harness-specific reasoning arguments when supplied', () => {
+    expect(buildExternalCommand(request('claude', 'high')).argv).toContain('--effort');
+    expect(buildExternalCommand(request('codex', 'high')).argv).toContain(
+      'model_reasoning_effort=high'
+    );
+    expect(buildExternalCommand(request('opencode', 'high')).argv).toContain('--variant');
+    for (const harness of ['cursor', 'gemini', 'copilot'] as const) {
+      expect(buildExternalCommand(request(harness, 'high')).argv.join(' ')).not.toContain('high');
+    }
+  });
+
+  it('falls back before launch when a harness lacks reasoning-effort support', () => {
+    let launches = 0;
+    const result = dispatchExternalTask(request('copilot', 'high'), {
+      ...readyDependencies(),
+      launch: () => {
+        launches += 1;
+        return { exitCode: 0 };
+      },
+    });
+    expect(result).toEqual({
+      kind: 'fallback',
+      reason: 'unsupported-reasoning-effort',
+      detail: 'copilot does not support a generic reasoning_effort override.',
+    });
+    expect(launches).toBe(0);
+  });
+
+  it('returns pre-launch fallback without launching when executable is unavailable', () => {
+    let launches = 0;
+    const result = dispatchExternalTask(request('copilot'), {
+      ...readyDependencies(),
+      executableExists: () => false,
+      launch: () => {
+        launches += 1;
+        return { exitCode: 0 };
+      },
+    });
+    expect(result).toEqual({
+      kind: 'fallback',
+      reason: 'executable-unavailable',
+      detail: 'copilot is unavailable.',
+    });
+    expect(launches).toBe(0);
+  });
+
+  it('returns pre-launch fallback without launching when authentication fails', () => {
+    let launches = 0;
+    const result = dispatchExternalTask(request('codex'), {
+      ...readyDependencies(),
+      authenticate: () => ({ ok: false, detail: 'authentication check failed' }),
+      launch: () => {
+        launches += 1;
+        return { exitCode: 0 };
+      },
+    });
+    expect(result).toEqual({
+      kind: 'fallback',
+      reason: 'authentication-failed',
+      detail: 'authentication check failed',
+    });
+    expect(launches).toBe(0);
+  });
+
+  it('reports a launched nonzero process as failure and never performs a native retry', () => {
+    let launches = 0;
+    const result = dispatchExternalTask(request('gemini'), {
+      ...readyDependencies(),
+      launch: () => {
+        launches += 1;
+        return { exitCode: 9 };
+      },
+    });
+    expect(result).toEqual({ kind: 'launched-failure', exitCode: 9 });
+    expect(launches).toBe(1);
+  });
+});

--- a/src/__tests__/st-full-workflow.skill.test.ts
+++ b/src/__tests__/st-full-workflow.skill.test.ts
@@ -1,6 +1,6 @@
 /**
  * Integration tests for the st-full-workflow skill bundles.
- * Covers the five generated .cjs scripts with fixture-based smoke tests.
+ * Covers the generated .cjs scripts with fixture-based smoke tests.
  */
 
 import * as fs from 'fs';
@@ -140,6 +140,11 @@ describe('st-full-workflow bundle smoke', () => {
       env: { ...process.env, NO_COLOR: '1' },
     }).trim();
     expect(stdout).toBe('3');
+  });
+
+  test('ships the task execution dispatcher referenced by the skill', () => {
+    const script = path.join(fixtureSkillDir, 'scripts', 'dispatch-task-execution.cjs');
+    expect(fs.statSync(script).isFile()).toBe(true);
   });
 
   test('create-feature-branch.cjs creates and switches to feature branch', () => {

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -34,10 +34,10 @@ describe('Critical Utils Business Logic', () => {
 
     it('should reject invalid harnesses', () => {
       expect(() => parseHarnesses('invalid')).toThrow(
-        'Invalid harness(es): invalid. Valid options are: claude, codex, cursor, gemini, github, opencode'
+        'Invalid harness(es): invalid. Valid options are: claude, codex, cursor, gemini, copilot, opencode'
       );
       expect(() => parseHarnesses('claude,invalid,unknown')).toThrow(
-        'Invalid harness(es): invalid, unknown. Valid options are: claude, codex, cursor, gemini, github, opencode'
+        'Invalid harness(es): invalid, unknown. Valid options are: claude, codex, cursor, gemini, copilot, opencode'
       );
     });
   });
@@ -46,7 +46,7 @@ describe('Critical Utils Business Logic', () => {
     it('should accept valid harnesses', () => {
       expect(() => validateHarnesses(['claude'])).not.toThrow();
       expect(() => validateHarnesses(['claude', 'gemini'])).not.toThrow();
-      expect(() => validateHarnesses(['opencode'])).not.toThrow();
+      expect(() => validateHarnesses(['copilot'])).not.toThrow();
       expect(() => validateHarnesses(['claude', 'gemini', 'opencode'])).not.toThrow();
     });
 
@@ -56,7 +56,7 @@ describe('Critical Utils Business Logic', () => {
 
     it('should reject invalid harnesses', () => {
       expect(() => validateHarnesses(['invalid' as Harness])).toThrow(
-        'Invalid harness: invalid. Supported harnesses: claude, codex, cursor, gemini, github, opencode'
+        'Invalid harness: invalid. Supported harnesses: claude, codex, cursor, gemini, copilot, opencode'
       );
     });
   });
@@ -100,10 +100,10 @@ describe('Critical Utils Business Logic', () => {
       });
     });
 
-    it('returns .agent.md extension for github', () => {
-      expect(getAgentFormat('github')).toEqual({
+    it('returns .md extension for copilot', () => {
+      expect(getAgentFormat('copilot')).toEqual({
         format: 'md',
-        extension: '.agent.md',
+        extension: '.md',
         directory: '.github/agents',
       });
     });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,7 @@ program
   .description('Initialize a new Strikethroo project')
   .requiredOption(
     '--harnesses <value>',
-    'Comma-separated list of harnesses to configure (claude,codex,cursor,gemini,github,opencode)'
+    'Comma-separated list of harnesses to configure (claude,codex,cursor,gemini,copilot,opencode)'
   )
   .option(
     '--destination-directory <path>',

--- a/src/skill-prompts/sections/phase-execution-loop.md
+++ b/src/skill-prompts/sections/phase-execution-loop.md
@@ -8,7 +8,23 @@ Read `<root>/config/hooks/PRE_PHASE.md` and execute its instructions before star
 {{heading}} {{phase_step}}b. Task dispatch
 Identify all tasks scheduled for this phase whose dependencies are fully satisfied. Read `<root>/config/hooks/PRE_TASK_ASSIGNMENT.md` and follow its instructions for agent selection before dispatching tasks.
 
-Deploy all selected agents simultaneously using your internal Task tool. Each agent MUST:
+For each selected task, before native dispatch run:
+
+```text
+scripts/dispatch-task-execution.cjs <task-file> <current-harness> <workspace> <plan-id> <task-id>
+```
+
+`<current-harness>` is the exact supported harness identifier running this
+skill and `<workspace>` is the project working directory. Interpret its JSON
+result before choosing a route: `native-default` uses ordinary native dispatch;
+`native-override` uses native dispatch with explicit exact-model prose and
+reasoning-effort prose only when returned; `fallback` visibly records its
+reason then uses ordinary native dispatch with no override prose;
+`launched-success` has already completed externally and receives normal status
+and evidence review; `launched-failure` is a failed task and must enter the
+existing error-hook/status path without any native retry.
+
+Deploy all remaining native agents simultaneously using your internal Task tool. Each agent MUST:
 
 1. Read and execute `<root>/config/hooks/PRE_TASK_EXECUTION.md` before starting any implementation work.
 2. Execute the task according to its requirements.

--- a/src/skill-prompts/sections/phase-execution-loop.md
+++ b/src/skill-prompts/sections/phase-execution-loop.md
@@ -8,11 +8,25 @@ Read `<root>/config/hooks/PRE_PHASE.md` and execute its instructions before star
 {{heading}} {{phase_step}}b. Task dispatch
 Identify all tasks scheduled for this phase whose dependencies are fully satisfied. Read `<root>/config/hooks/PRE_TASK_ASSIGNMENT.md` and follow its instructions for agent selection before dispatching tasks.
 
-For each selected task, before native dispatch run:
+Resolve every selected task's execution route first. Invoke one resolver per selected
+task simultaneously in a single parallel tool operation:
 
 ```text
-scripts/dispatch-task-execution.cjs <task-file> <current-harness> <workspace> <plan-id> <task-id>
+scripts/dispatch-task-execution.cjs resolve <task-file> <current-harness> <workspace> <plan-id> <task-id>
 ```
+
+Resolvers never launch external processes. After interpreting all route results, issue
+all `external-override` executions and all native Task-tool agents **together in one
+parallel tool operation**. External execution uses:
+
+```text
+scripts/dispatch-task-execution.cjs execute <task-file> <current-harness> <workspace> <plan-id> <task-id>
+```
+
+This two-step protocol is mandatory: do not execute external tasks during route
+resolution, do not serialize external commands, and do not wait for external completion
+before launching ready native agents. If an execute-time pre-flight returns `fallback`,
+record its reason and immediately launch the ordinary native path without override prose.
 
 `<current-harness>` is the exact supported harness identifier running this
 skill and `<workspace>` is the project working directory. Interpret its JSON
@@ -22,7 +36,11 @@ reasoning-effort prose only when returned; `fallback` visibly records its
 reason then uses ordinary native dispatch with no override prose;
 `launched-success` has already completed externally and receives normal status
 and evidence review; `launched-failure` is a failed task and must enter the
-existing error-hook/status path without any native retry.
+existing error-hook/status path without any native retry; `infrastructure-failure`
+is also a failed task, must be marked failed, and must run
+`<root>/config/hooks/POST_ERROR_DETECTION.md` without native retry. The command
+always emits exactly one JSON line; exit code `2` identifies entrypoint/infrastructure
+failure while exit code `1` identifies a launched task failure.
 
 Deploy all remaining native agents simultaneously using your internal Task tool. Each agent MUST:
 

--- a/src/skill-prompts/sections/task-file-output.md
+++ b/src/skill-prompts/sections/task-file-output.md
@@ -23,6 +23,10 @@ Optional frontmatter:
 - `complexity_notes` (string) — include when the score needs justification,
   such as "Decomposed from a cross-cutting parent task" or "Ambiguous API
   contract".
+- `execution` (mapping) — a task-only execution override. When present,
+  `model` is required and must be an exact string. `reasoning_effort` and a
+  different external `harness` are optional. Do not create plan defaults,
+  inheritance, aliases, model discovery, or model-name translation.
 
 The body sections (Objective, Skills Required, Acceptance Criteria, Technical
 Requirements, Input Dependencies, Output Artifacts, Implementation Notes)

--- a/src/skill-prompts/st-execute-task.md
+++ b/src/skill-prompts/st-execute-task.md
@@ -119,8 +119,32 @@ Preserve all other frontmatter fields exactly.
 
 ### 8. Execute the task
 
-Deploy an agent using your internal Task tool. The agent MUST perform these
-steps in order:
+Before deploying a native agent, consult the bundled policy/dispatch runtime:
+
+```text
+scripts/dispatch-task-execution.cjs <task-file> <current-harness> <workspace> <plan-id> <task-id>
+```
+
+`<current-harness>` is the exact supported harness identifier running this
+skill; `<workspace>` is the project working directory. Read the one-line JSON
+result and act exactly once:
+
+- `native-default`: use the ordinary native Task dispatch below with no
+  execution-setting prose.
+- `native-override`: use native dispatch and explicitly require the subagent
+  to use the exact returned `model`. Mention `reasoningEffort` only when that
+  property is present.
+- `fallback`: visibly record the returned reason and detail, then use ordinary
+  native dispatch with no execution-setting prose. This is a pre-launch
+  fallback only.
+- `launched-success`: the external harness has completed the task; do not
+  dispatch a native agent. Continue directly with status and evidence review.
+- `launched-failure` (the script exits 1): treat it as an execution failure.
+  Do not dispatch or retry natively; follow steps 9–11's failed-status and
+  error-hook path.
+
+For either native dispatch outcome, deploy an agent using your internal Task
+tool. The agent MUST perform these steps in order:
 
 1. **Pre-flight validation**: Read and execute
    `<root>/config/hooks/PRE_TASK_EXECUTION.md` before starting any

--- a/src/skill-scripts/dispatch-task-execution.ts
+++ b/src/skill-scripts/dispatch-task-execution.ts
@@ -5,40 +5,69 @@ import { SUPPORTED_HARNESSES, type Harness } from '../types';
 import { dispatchExternalTask } from './shared/external-dispatch';
 import { readTaskExecutionPolicy } from './shared/execution-policy';
 
-const [taskFile, currentHarness, workspace, planId, taskId] = process.argv.slice(2);
-if (!taskFile || !currentHarness || !workspace || !planId || !taskId) {
-  process.stderr.write(
-    'Usage: dispatch-task-execution.cjs <task-file> <current-harness> <workspace> <plan-id> <task-id>\n'
+const emit = (result: object, exitCode: number): never => {
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  process.exit(exitCode);
+};
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const main = async (): Promise<void> => {
+  const args = process.argv.slice(2);
+  const mode = args[0] === 'resolve' || args[0] === 'execute' ? args.shift() : 'execute';
+  if (args.length < 5 || args.slice(0, 5).some(value => !value)) {
+    emit(
+      {
+        kind: 'infrastructure-failure',
+        detail:
+          'Usage: dispatch-task-execution.cjs [resolve|execute] <task-file> ' +
+          '<current-harness> <workspace> <plan-id> <task-id>',
+      },
+      2
+    );
+  }
+  const [taskFile, currentHarness, workspace, planId, taskId] = args as [
+    string,
+    string,
+    string,
+    string,
+    string,
+  ];
+
+  const taskPath = path.resolve(taskFile);
+  const taskMarkdown = fs.readFileSync(taskPath, 'utf8');
+  const policy = readTaskExecutionPolicy(taskMarkdown, {
+    currentHarness,
+    supportedHarnesses: SUPPORTED_HARNESSES,
+  });
+  if (mode === 'resolve') emit(policy, 0);
+  if (policy.kind !== 'external-override') {
+    emit(policy.kind === 'native-default' ? { kind: 'native-default' } : policy, 0);
+  }
+
+  const externalPolicy = policy as Extract<typeof policy, { kind: 'external-override' }>;
+  const result = await dispatchExternalTask({
+    ...externalPolicy,
+    harness: externalPolicy.harness as Harness,
+    workspace: path.resolve(workspace),
+    planId,
+    taskId,
+    taskFile: taskPath,
+    taskMarkdown,
+  });
+  emit(
+    result,
+    result.kind === 'infrastructure-failure' ? 2 : result.kind === 'launched-failure' ? 1 : 0
   );
-  process.exit(2);
-}
+};
 
-const taskMarkdown = fs.readFileSync(path.resolve(taskFile), 'utf8');
-const policy = readTaskExecutionPolicy(taskMarkdown, {
-  currentHarness,
-  supportedHarnesses: SUPPORTED_HARNESSES,
+main().catch(error => {
+  emit(
+    {
+      kind: 'infrastructure-failure',
+      detail: `Task dispatch infrastructure failed: ${errorMessage(error)}`,
+    },
+    2
+  );
 });
-if (policy.kind === 'native-default') {
-  process.stdout.write(`${JSON.stringify({ kind: 'native-default' })}\n`);
-  process.exit(0);
-}
-if (policy.kind === 'native-override') {
-  process.stdout.write(`${JSON.stringify(policy)}\n`);
-  process.exit(0);
-}
-if (policy.kind === 'fallback') {
-  process.stdout.write(`${JSON.stringify(policy)}\n`);
-  process.exit(0);
-}
-
-const result = dispatchExternalTask({
-  ...policy,
-  harness: policy.harness as Harness,
-  workspace: path.resolve(workspace),
-  planId,
-  taskId,
-  taskFile: path.resolve(taskFile),
-  taskMarkdown,
-});
-process.stdout.write(`${JSON.stringify(result)}\n`);
-process.exit(result.kind === 'launched-failure' ? 1 : 0);

--- a/src/skill-scripts/dispatch-task-execution.ts
+++ b/src/skill-scripts/dispatch-task-execution.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import * as fs from 'fs';
+import * as path from 'path';
+import { SUPPORTED_HARNESSES, type Harness } from '../types';
+import { dispatchExternalTask } from './shared/external-dispatch';
+import { readTaskExecutionPolicy } from './shared/execution-policy';
+
+const [taskFile, currentHarness, workspace, planId, taskId] = process.argv.slice(2);
+if (!taskFile || !currentHarness || !workspace || !planId || !taskId) {
+  process.stderr.write(
+    'Usage: dispatch-task-execution.cjs <task-file> <current-harness> <workspace> <plan-id> <task-id>\n'
+  );
+  process.exit(2);
+}
+
+const taskMarkdown = fs.readFileSync(path.resolve(taskFile), 'utf8');
+const policy = readTaskExecutionPolicy(taskMarkdown, {
+  currentHarness,
+  supportedHarnesses: SUPPORTED_HARNESSES,
+});
+if (policy.kind === 'native-default') {
+  process.stdout.write(`${JSON.stringify({ kind: 'native-default' })}\n`);
+  process.exit(0);
+}
+if (policy.kind === 'native-override') {
+  process.stdout.write(`${JSON.stringify(policy)}\n`);
+  process.exit(0);
+}
+if (policy.kind === 'fallback') {
+  process.stdout.write(`${JSON.stringify(policy)}\n`);
+  process.exit(0);
+}
+
+const result = dispatchExternalTask({
+  ...policy,
+  harness: policy.harness as Harness,
+  workspace: path.resolve(workspace),
+  planId,
+  taskId,
+  taskFile: path.resolve(taskFile),
+  taskMarkdown,
+});
+process.stdout.write(`${JSON.stringify(result)}\n`);
+process.exit(result.kind === 'launched-failure' ? 1 : 0);

--- a/src/skill-scripts/shared/execution-policy.ts
+++ b/src/skill-scripts/shared/execution-policy.ts
@@ -1,0 +1,109 @@
+import matter from 'gray-matter';
+
+export interface ExecutionPolicyContext {
+  currentHarness: string;
+  supportedHarnesses: readonly string[];
+}
+
+export type ExecutionPolicy =
+  | { kind: 'native-default' }
+  | { kind: 'native-override'; model: string; reasoningEffort?: string }
+  | {
+      kind: 'external-override';
+      harness: string;
+      model: string;
+      reasoningEffort?: string;
+    }
+  | {
+      kind: 'fallback';
+      reason:
+        | 'invalid-frontmatter'
+        | 'invalid-execution'
+        | 'missing-model'
+        | 'invalid-model'
+        | 'invalid-reasoning-effort'
+        | 'invalid-harness'
+        | 'unsupported-harness'
+        | 'same-orchestrator-harness';
+      detail: string;
+    };
+
+const fallback = (
+  reason: Extract<ExecutionPolicy, { kind: 'fallback' }>['reason'],
+  detail: string
+): ExecutionPolicy => ({ kind: 'fallback', reason, detail });
+
+const hasOwn = (value: Record<string, unknown>, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+/**
+ * Reads only a task document's optional execution mapping. It deliberately has
+ * no plan input, preventing defaults or inheritance from entering the contract.
+ */
+export const readTaskExecutionPolicy = (
+  taskMarkdown: string,
+  context: ExecutionPolicyContext
+): ExecutionPolicy => {
+  let data: Record<string, unknown>;
+  try {
+    const parsed = matter(taskMarkdown);
+    if (!parsed.matter) return { kind: 'native-default' };
+    data = parsed.data;
+  } catch (error) {
+    return fallback(
+      'invalid-frontmatter',
+      `Task execution override was skipped: ${error instanceof Error ? error.message : 'invalid YAML'}`
+    );
+  }
+
+  if (!hasOwn(data, 'execution')) return { kind: 'native-default' };
+  const execution = data.execution;
+  if (!execution || Array.isArray(execution) || typeof execution !== 'object') {
+    return fallback('invalid-execution', 'Task execution override must be a YAML mapping.');
+  }
+
+  const policy = execution as Record<string, unknown>;
+  if (!hasOwn(policy, 'model')) {
+    return fallback('missing-model', 'Task execution override requires an exact model string.');
+  }
+  if (typeof policy.model !== 'string' || policy.model.length === 0) {
+    return fallback('invalid-model', 'Task execution model must be a non-empty string.');
+  }
+  if (hasOwn(policy, 'reasoning_effort') && typeof policy.reasoning_effort !== 'string') {
+    return fallback(
+      'invalid-reasoning-effort',
+      'Task reasoning_effort must be a string when provided.'
+    );
+  }
+
+  const model = policy.model;
+  const reasoningEffort = policy.reasoning_effort as string | undefined;
+  if (!hasOwn(policy, 'harness')) {
+    return reasoningEffort === undefined
+      ? { kind: 'native-override', model }
+      : { kind: 'native-override', model, reasoningEffort };
+  }
+
+  if (typeof policy.harness !== 'string' || policy.harness.length === 0) {
+    return fallback(
+      'invalid-harness',
+      'Task execution harness must be a non-empty string when provided.'
+    );
+  }
+  if (!context.supportedHarnesses.includes(policy.harness)) {
+    return fallback(
+      'unsupported-harness',
+      `Task execution harness "${policy.harness}" is not supported.`
+    );
+  }
+  if (policy.harness === context.currentHarness) {
+    return fallback(
+      'same-orchestrator-harness',
+      'Task execution harness must differ from the current orchestrator.'
+    );
+  }
+
+  return reasoningEffort === undefined
+    ? { kind: 'external-override', harness: policy.harness, model }
+    : { kind: 'external-override', harness: policy.harness, model, reasoningEffort };
+};

--- a/src/skill-scripts/shared/external-dispatch.ts
+++ b/src/skill-scripts/shared/external-dispatch.ts
@@ -1,0 +1,237 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { SUPPORTED_HARNESSES, type Harness } from '../../types';
+
+/**
+ * CLI contracts were verified against their official CLI documentation:
+ * Claude: https://docs.anthropic.com/en/docs/claude-code/cli-reference
+ * Codex: https://developers.openai.com/codex/cli/reference/
+ * Cursor: https://docs.cursor.com/en/cli/reference/commands
+ * Gemini: https://google-gemini.github.io/gemini-cli/docs/cli/commands/
+ * Copilot: https://docs.github.com/en/copilot/reference/copilot-cli-reference
+ * OpenCode: https://opencode.ai/docs/cli/
+ *
+ * The adapters intentionally accept the task model verbatim. They do not
+ * discover, normalize, default, or inherit model settings.
+ */
+export interface ExternalDispatchRequest {
+  harness: Harness;
+  model: string;
+  reasoningEffort?: string;
+  workspace: string;
+  planId: string;
+  taskId: string;
+  taskFile: string;
+  taskMarkdown: string;
+}
+
+export interface StructuredCommand {
+  executable: string;
+  argv: string[];
+  cwd: string;
+}
+
+export type ExternalDispatchResult =
+  | { kind: 'launched-success'; exitCode: 0 }
+  | { kind: 'launched-failure'; exitCode: number }
+  | {
+      kind: 'fallback';
+      reason:
+        | 'adapter-unavailable'
+        | 'executable-unavailable'
+        | 'authentication-failed'
+        | 'unsupported-reasoning-effort';
+      detail: string;
+    };
+
+export interface ExternalDispatchDependencies {
+  executableExists: (executable: string) => boolean;
+  authenticate: (
+    command: StructuredCommand,
+    adapter: ExternalHarnessAdapter
+  ) => { ok: boolean; detail?: string };
+  launch: (command: StructuredCommand) => { exitCode: number };
+}
+
+export interface ExternalHarnessAdapter {
+  executable: string;
+  buildCommand: (request: ExternalDispatchRequest) => StructuredCommand;
+  authenticationArgv: () => string[];
+}
+
+const taskPrompt = (request: ExternalDispatchRequest): string =>
+  `Strikethroo external task dispatch — Plan ${request.planId}, Task ${request.taskId}.\n` +
+  `Workspace: ${request.workspace}\nTask file: ${request.taskFile}\n\n` +
+  `Read and implement this task. Preserve its lifecycle requirements and report failures clearly.\n\n${request.taskMarkdown}`;
+
+const command = (
+  executable: string,
+  argv: string[],
+  request: ExternalDispatchRequest
+): StructuredCommand => ({
+  executable,
+  argv,
+  cwd: request.workspace,
+});
+
+export const EXTERNAL_HARNESS_ADAPTERS: Readonly<Record<Harness, ExternalHarnessAdapter>> = {
+  claude: {
+    executable: 'claude',
+    buildCommand: request =>
+      command(
+        'claude',
+        [
+          '-p',
+          taskPrompt(request),
+          '--model',
+          request.model,
+          ...(request.reasoningEffort === undefined ? [] : ['--effort', request.reasoningEffort]),
+        ],
+        request
+      ),
+    authenticationArgv: () => ['auth', 'status'],
+  },
+  codex: {
+    executable: 'codex',
+    buildCommand: request =>
+      command(
+        'codex',
+        [
+          'exec',
+          '--model',
+          request.model,
+          ...(request.reasoningEffort === undefined
+            ? []
+            : ['--config', `model_reasoning_effort=${request.reasoningEffort}`]),
+          taskPrompt(request),
+        ],
+        request
+      ),
+    authenticationArgv: () => ['login', 'status'],
+  },
+  cursor: {
+    executable: 'cursor-agent',
+    buildCommand: request =>
+      command('cursor-agent', ['--print', '--model', request.model, taskPrompt(request)], request),
+    authenticationArgv: () => ['status'],
+  },
+  gemini: {
+    executable: 'gemini',
+    buildCommand: request =>
+      command('gemini', ['--prompt', taskPrompt(request), '--model', request.model], request),
+    authenticationArgv: () => ['auth', 'status'],
+  },
+  copilot: {
+    executable: 'copilot',
+    buildCommand: request =>
+      command('copilot', ['-p', taskPrompt(request), '--model', request.model], request),
+    authenticationArgv: () => ['auth', 'status'],
+  },
+  opencode: {
+    executable: 'opencode',
+    buildCommand: request =>
+      command(
+        'opencode',
+        [
+          'run',
+          '--model',
+          request.model,
+          ...(request.reasoningEffort === undefined ? [] : ['--variant', request.reasoningEffort]),
+          taskPrompt(request),
+        ],
+        request
+      ),
+    authenticationArgv: () => ['auth', 'list'],
+  },
+};
+
+const adapterKeys = Object.keys(EXTERNAL_HARNESS_ADAPTERS).sort();
+const harnessKeys = [...SUPPORTED_HARNESSES].sort();
+if (adapterKeys.join('\0') !== harnessKeys.join('\0')) {
+  throw new Error('External harness adapter registry does not cover SUPPORTED_HARNESSES exactly.');
+}
+
+export const buildExternalCommand = (request: ExternalDispatchRequest): StructuredCommand =>
+  EXTERNAL_HARNESS_ADAPTERS[request.harness].buildCommand(request);
+
+const executableOnPath = (executable: string): boolean =>
+  (process.env.PATH ?? '').split(path.delimiter).some(directory => {
+    if (!directory) return false;
+    const candidate = path.join(directory, executable);
+    try {
+      return fs.statSync(candidate).isFile();
+    } catch {
+      return false;
+    }
+  });
+
+const dependencies: ExternalDispatchDependencies = {
+  executableExists: executableOnPath,
+  authenticate: (commandSpec, adapter) => {
+    const result = spawnSync(commandSpec.executable, adapter.authenticationArgv(), {
+      cwd: commandSpec.cwd,
+      encoding: 'utf8',
+      shell: false,
+      stdio: 'pipe',
+    });
+    return result.status === 0
+      ? { ok: true }
+      : { ok: false, detail: `${commandSpec.executable} authentication check failed.` };
+  },
+  launch: commandSpec => {
+    const result = spawnSync(commandSpec.executable, commandSpec.argv, {
+      cwd: commandSpec.cwd,
+      encoding: 'utf8',
+      shell: false,
+      stdio: 'inherit',
+    });
+    return { exitCode: result.status ?? 1 };
+  },
+};
+
+/** Only pre-launch failures return fallback. A launched process is always committed. */
+export const dispatchExternalTask = (
+  request: ExternalDispatchRequest,
+  overrides: Partial<ExternalDispatchDependencies> = {}
+): ExternalDispatchResult => {
+  const adapter = EXTERNAL_HARNESS_ADAPTERS[request.harness];
+  if (!adapter) {
+    return {
+      kind: 'fallback',
+      reason: 'adapter-unavailable',
+      detail: `No adapter is registered for ${request.harness}.`,
+    };
+  }
+  const active = { ...dependencies, ...overrides };
+  if (
+    request.reasoningEffort !== undefined &&
+    (request.harness === 'cursor' || request.harness === 'gemini' || request.harness === 'copilot')
+  ) {
+    return {
+      kind: 'fallback',
+      reason: 'unsupported-reasoning-effort',
+      detail: `${request.harness} does not support a generic reasoning_effort override.`,
+    };
+  }
+  if (!active.executableExists(adapter.executable)) {
+    return {
+      kind: 'fallback',
+      reason: 'executable-unavailable',
+      detail: `${adapter.executable} is unavailable.`,
+    };
+  }
+  const commandSpec = adapter.buildCommand(request);
+  const authentication = active.authenticate(commandSpec, adapter);
+  if (!authentication.ok) {
+    return {
+      kind: 'fallback',
+      reason: 'authentication-failed',
+      detail: authentication.detail ?? `${adapter.executable} authentication check failed.`,
+    };
+  }
+  const launched = active.launch(commandSpec);
+  return launched.exitCode === 0
+    ? { kind: 'launched-success', exitCode: 0 }
+    : { kind: 'launched-failure', exitCode: launched.exitCode };
+};

--- a/src/skill-scripts/shared/external-dispatch.ts
+++ b/src/skill-scripts/shared/external-dispatch.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { spawnSync } from 'child_process';
+import { spawn } from 'child_process';
 import { SUPPORTED_HARNESSES, type Harness } from '../../types';
 
 /**
@@ -12,8 +12,8 @@ import { SUPPORTED_HARNESSES, type Harness } from '../../types';
  * Copilot: https://docs.github.com/en/copilot/reference/copilot-cli-reference
  * OpenCode: https://opencode.ai/docs/cli/
  *
- * The adapters intentionally accept the task model verbatim. They do not
- * discover, normalize, default, or inherit model settings.
+ * Adapters pass model identifiers through verbatim and send task content through
+ * stdin so it is neither process-visible argv nor constrained by ARG_MAX.
  */
 export interface ExternalDispatchRequest {
   harness: Harness;
@@ -30,11 +30,13 @@ export interface StructuredCommand {
   executable: string;
   argv: string[];
   cwd: string;
+  stdin: string;
 }
 
 export type ExternalDispatchResult =
   | { kind: 'launched-success'; exitCode: 0 }
   | { kind: 'launched-failure'; exitCode: number }
+  | { kind: 'infrastructure-failure'; detail: string }
   | {
       kind: 'fallback';
       reason:
@@ -50,8 +52,8 @@ export interface ExternalDispatchDependencies {
   authenticate: (
     command: StructuredCommand,
     adapter: ExternalHarnessAdapter
-  ) => { ok: boolean; detail?: string };
-  launch: (command: StructuredCommand) => { exitCode: number };
+  ) => Promise<{ ok: boolean; detail?: string }>;
+  launch: (command: StructuredCommand) => Promise<{ exitCode: number }>;
 }
 
 export interface ExternalHarnessAdapter {
@@ -62,8 +64,13 @@ export interface ExternalHarnessAdapter {
 
 const taskPrompt = (request: ExternalDispatchRequest): string =>
   `Strikethroo external task dispatch — Plan ${request.planId}, Task ${request.taskId}.\n` +
-  `Workspace: ${request.workspace}\nTask file: ${request.taskFile}\n\n` +
-  `Read and implement this task. Preserve its lifecycle requirements and report failures clearly.\n\n${request.taskMarkdown}`;
+  `Workspace: ${request.workspace}\nTask file: ${request.taskFile}\n` +
+  `Before implementation, read and execute ${path.join(
+    request.workspace,
+    '.ai/strikethroo/config/hooks/PRE_TASK_EXECUTION.md'
+  )}. Halt if that hook fails.\n\n` +
+  `Read and implement this task. Preserve dependency validation, status transitions, ` +
+  `evidence reporting, and error-hook handling. Report failures clearly.\n\n${request.taskMarkdown}`;
 
 const command = (
   executable: string,
@@ -73,6 +80,7 @@ const command = (
   executable,
   argv,
   cwd: request.workspace,
+  stdin: taskPrompt(request),
 });
 
 export const EXTERNAL_HARNESS_ADAPTERS: Readonly<Record<Harness, ExternalHarnessAdapter>> = {
@@ -83,7 +91,6 @@ export const EXTERNAL_HARNESS_ADAPTERS: Readonly<Record<Harness, ExternalHarness
         'claude',
         [
           '-p',
-          taskPrompt(request),
           '--model',
           request.model,
           ...(request.reasoningEffort === undefined ? [] : ['--effort', request.reasoningEffort]),
@@ -104,7 +111,7 @@ export const EXTERNAL_HARNESS_ADAPTERS: Readonly<Record<Harness, ExternalHarness
           ...(request.reasoningEffort === undefined
             ? []
             : ['--config', `model_reasoning_effort=${request.reasoningEffort}`]),
-          taskPrompt(request),
+          '-',
         ],
         request
       ),
@@ -113,19 +120,17 @@ export const EXTERNAL_HARNESS_ADAPTERS: Readonly<Record<Harness, ExternalHarness
   cursor: {
     executable: 'cursor-agent',
     buildCommand: request =>
-      command('cursor-agent', ['--print', '--model', request.model, taskPrompt(request)], request),
+      command('cursor-agent', ['--print', '--model', request.model], request),
     authenticationArgv: () => ['status'],
   },
   gemini: {
     executable: 'gemini',
-    buildCommand: request =>
-      command('gemini', ['--prompt', taskPrompt(request), '--model', request.model], request),
+    buildCommand: request => command('gemini', ['--prompt', '', '--model', request.model], request),
     authenticationArgv: () => ['auth', 'status'],
   },
   copilot: {
     executable: 'copilot',
-    buildCommand: request =>
-      command('copilot', ['-p', taskPrompt(request), '--model', request.model], request),
+    buildCommand: request => command('copilot', ['-p', '', '--model', request.model], request),
     authenticationArgv: () => ['auth', 'status'],
   },
   opencode: {
@@ -138,7 +143,7 @@ export const EXTERNAL_HARNESS_ADAPTERS: Readonly<Record<Harness, ExternalHarness
           '--model',
           request.model,
           ...(request.reasoningEffort === undefined ? [] : ['--variant', request.reasoningEffort]),
-          taskPrompt(request),
+          '-',
         ],
         request
       ),
@@ -166,35 +171,76 @@ const executableOnPath = (executable: string): boolean =>
     }
   });
 
+const runProcess = (
+  executable: string,
+  argv: string[],
+  cwd: string,
+  stdin?: string,
+  inheritOutput = false
+): Promise<{ exitCode: number }> =>
+  new Promise((resolve, reject) => {
+    let settled = false;
+    const fail = (error: Error): void => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+    const child = spawn(executable, argv, {
+      cwd,
+      shell: false,
+      stdio: [
+        stdin === undefined ? 'ignore' : 'pipe',
+        inheritOutput ? 'inherit' : 'ignore',
+        inheritOutput ? 'inherit' : 'ignore',
+      ],
+    });
+    child.once('error', fail);
+    child.once('close', code => {
+      if (settled) return;
+      settled = true;
+      resolve({ exitCode: code ?? 1 });
+    });
+    if (stdin !== undefined) {
+      child.stdin!.once('error', fail);
+      try {
+        child.stdin!.end(stdin);
+      } catch (error) {
+        fail(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+  });
+
 const dependencies: ExternalDispatchDependencies = {
   executableExists: executableOnPath,
-  authenticate: (commandSpec, adapter) => {
-    const result = spawnSync(commandSpec.executable, adapter.authenticationArgv(), {
-      cwd: commandSpec.cwd,
-      encoding: 'utf8',
-      shell: false,
-      stdio: 'pipe',
-    });
-    return result.status === 0
-      ? { ok: true }
-      : { ok: false, detail: `${commandSpec.executable} authentication check failed.` };
+  authenticate: async (commandSpec, adapter) => {
+    try {
+      const result = await runProcess(
+        commandSpec.executable,
+        adapter.authenticationArgv(),
+        commandSpec.cwd
+      );
+      return result.exitCode === 0
+        ? { ok: true }
+        : { ok: false, detail: `${commandSpec.executable} authentication check failed.` };
+    } catch (error) {
+      return {
+        ok: false,
+        detail: `${commandSpec.executable} authentication check failed: ${errorMessage(error)}`,
+      };
+    }
   },
-  launch: commandSpec => {
-    const result = spawnSync(commandSpec.executable, commandSpec.argv, {
-      cwd: commandSpec.cwd,
-      encoding: 'utf8',
-      shell: false,
-      stdio: 'inherit',
-    });
-    return { exitCode: result.status ?? 1 };
-  },
+  launch: commandSpec =>
+    runProcess(commandSpec.executable, commandSpec.argv, commandSpec.cwd, commandSpec.stdin, true),
 };
 
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
 /** Only pre-launch failures return fallback. A launched process is always committed. */
-export const dispatchExternalTask = (
+export const dispatchExternalTask = async (
   request: ExternalDispatchRequest,
   overrides: Partial<ExternalDispatchDependencies> = {}
-): ExternalDispatchResult => {
+): Promise<ExternalDispatchResult> => {
   const adapter = EXTERNAL_HARNESS_ADAPTERS[request.harness];
   if (!adapter) {
     return {
@@ -222,7 +268,7 @@ export const dispatchExternalTask = (
     };
   }
   const commandSpec = adapter.buildCommand(request);
-  const authentication = active.authenticate(commandSpec, adapter);
+  const authentication = await active.authenticate(commandSpec, adapter);
   if (!authentication.ok) {
     return {
       kind: 'fallback',
@@ -230,8 +276,15 @@ export const dispatchExternalTask = (
       detail: authentication.detail ?? `${adapter.executable} authentication check failed.`,
     };
   }
-  const launched = active.launch(commandSpec);
-  return launched.exitCode === 0
-    ? { kind: 'launched-success', exitCode: 0 }
-    : { kind: 'launched-failure', exitCode: launched.exitCode };
+  try {
+    const launched = await active.launch(commandSpec);
+    return launched.exitCode === 0
+      ? { kind: 'launched-success', exitCode: 0 }
+      : { kind: 'launched-failure', exitCode: launched.exitCode };
+  } catch (error) {
+    return {
+      kind: 'infrastructure-failure',
+      detail: `External task process failed: ${errorMessage(error)}`,
+    };
+  }
 };

--- a/src/skill-scripts/shared/task-file.ts
+++ b/src/skill-scripts/shared/task-file.ts
@@ -77,6 +77,35 @@ export const extractStatus = (frontmatter: string): string | null => {
   return null;
 };
 
+/**
+ * Changes only the root-level status line in a task's leading frontmatter.
+ * The raw replacement preserves every other byte, including nested mappings.
+ */
+export const rewriteTaskStatus = (taskMarkdown: string, status: string): string => {
+  const match = taskMarkdown.match(/^(---\r?\n)([\s\S]*?)(\r?\n---)/);
+  if (!match) throw new Error('missing frontmatter');
+
+  const opening = match[1];
+  const frontmatter = match[2];
+  const closing = match[3];
+  if (opening === undefined || frontmatter === undefined || closing === undefined) {
+    throw new Error('missing frontmatter');
+  }
+  const statusLines = frontmatter.match(/^status:[^\r\n]*/gm) ?? [];
+  if (statusLines.length === 0) throw new Error('missing root status');
+  if (statusLines.length > 1) throw new Error('duplicate root status');
+  const statusLine = statusLines[0];
+  if (statusLine === undefined) throw new Error('missing root status');
+
+  const replacement = statusLine.replace(
+    /^status:([ \t]*)(?:["'][^\r\n]*?["']|[^\r\n]*?)([ \t]*(?:#.*)?)$/,
+    (_line, spacing: string, comment: string) => `status:${spacing}"${status}"${comment}`
+  );
+  return `${opening}${frontmatter.replace(statusLine, replacement)}${closing}${taskMarkdown.slice(
+    match[0].length
+  )}`;
+};
+
 export interface TaskReadinessIssue {
   taskId: string;
   kind: 'missing' | 'needs-clarification' | 'unresolved-dependency';

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,16 @@
 /**
  * Supported AI harnesses for task management
  */
-export type Harness = 'claude' | 'codex' | 'cursor' | 'gemini' | 'github' | 'opencode';
+export const SUPPORTED_HARNESSES = [
+  'claude',
+  'codex',
+  'cursor',
+  'gemini',
+  'copilot',
+  'opencode',
+] as const;
+
+export type Harness = (typeof SUPPORTED_HARNESSES)[number];
 
 /**
  * Options for the init command

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,16 +4,7 @@
  * Validation helpers for the `--harnesses` option.
  */
 
-import { Harness } from './types';
-
-const VALID_HARNESSES: readonly Harness[] = [
-  'claude',
-  'codex',
-  'cursor',
-  'gemini',
-  'github',
-  'opencode',
-];
+import { Harness, SUPPORTED_HARNESSES } from './types';
 
 /**
  * Parse comma-separated harness values into an array
@@ -32,12 +23,12 @@ export function parseHarnesses(value: string): Harness[] {
     .filter(a => a.length > 0);
 
   const invalidHarnesses = harnesses.filter(
-    (harness): harness is string => !VALID_HARNESSES.includes(harness as Harness)
+    (harness): harness is string => !SUPPORTED_HARNESSES.includes(harness as Harness)
   );
 
   if (invalidHarnesses.length > 0) {
     throw new Error(
-      `Invalid harness(es): ${invalidHarnesses.join(', ')}. Valid options are: ${VALID_HARNESSES.join(', ')}`
+      `Invalid harness(es): ${invalidHarnesses.join(', ')}. Valid options are: ${SUPPORTED_HARNESSES.join(', ')}`
     );
   }
 
@@ -55,9 +46,9 @@ export function validateHarnesses(harnesses: Harness[]): void {
   }
 
   for (const harness of harnesses) {
-    if (!VALID_HARNESSES.includes(harness)) {
+    if (!SUPPORTED_HARNESSES.includes(harness)) {
       throw new Error(
-        `Invalid harness: ${harness}. Supported harnesses: ${VALID_HARNESSES.join(', ')}`
+        `Invalid harness: ${harness}. Supported harnesses: ${SUPPORTED_HARNESSES.join(', ')}`
       );
     }
   }
@@ -177,8 +168,8 @@ export function getAgentFormat(harness: Harness): AgentFormatInfo {
   switch (harness) {
     case 'codex':
       return { format: 'toml', extension: '.toml', directory: '.codex/agents' };
-    case 'github':
-      return { format: 'md', extension: '.agent.md', directory: '.github/agents' };
+    case 'copilot':
+      return { format: 'md', extension: '.md', directory: '.github/agents' };
     case 'claude':
       return { format: 'md', extension: '.md', directory: '.claude/agents' };
     case 'gemini':

--- a/templates/harness/skills/st-execute-blueprint/SKILL.md
+++ b/templates/harness/skills/st-execute-blueprint/SKILL.md
@@ -87,7 +87,23 @@ Read `<root>/config/hooks/PRE_PHASE.md` and execute its instructions before star
 #### 7b. Task dispatch
 Identify all tasks scheduled for this phase whose dependencies are fully satisfied. Read `<root>/config/hooks/PRE_TASK_ASSIGNMENT.md` and follow its instructions for agent selection before dispatching tasks.
 
-Deploy all selected agents simultaneously using your internal Task tool. Each agent MUST:
+For each selected task, before native dispatch run:
+
+```text
+scripts/dispatch-task-execution.cjs <task-file> <current-harness> <workspace> <plan-id> <task-id>
+```
+
+`<current-harness>` is the exact supported harness identifier running this
+skill and `<workspace>` is the project working directory. Interpret its JSON
+result before choosing a route: `native-default` uses ordinary native dispatch;
+`native-override` uses native dispatch with explicit exact-model prose and
+reasoning-effort prose only when returned; `fallback` visibly records its
+reason then uses ordinary native dispatch with no override prose;
+`launched-success` has already completed externally and receives normal status
+and evidence review; `launched-failure` is a failed task and must enter the
+existing error-hook/status path without any native retry.
+
+Deploy all remaining native agents simultaneously using your internal Task tool. Each agent MUST:
 
 1. Read and execute `<root>/config/hooks/PRE_TASK_EXECUTION.md` before starting any implementation work.
 2. Execute the task according to its requirements.

--- a/templates/harness/skills/st-execute-blueprint/SKILL.md
+++ b/templates/harness/skills/st-execute-blueprint/SKILL.md
@@ -87,11 +87,25 @@ Read `<root>/config/hooks/PRE_PHASE.md` and execute its instructions before star
 #### 7b. Task dispatch
 Identify all tasks scheduled for this phase whose dependencies are fully satisfied. Read `<root>/config/hooks/PRE_TASK_ASSIGNMENT.md` and follow its instructions for agent selection before dispatching tasks.
 
-For each selected task, before native dispatch run:
+Resolve every selected task's execution route first. Invoke one resolver per selected
+task simultaneously in a single parallel tool operation:
 
 ```text
-scripts/dispatch-task-execution.cjs <task-file> <current-harness> <workspace> <plan-id> <task-id>
+scripts/dispatch-task-execution.cjs resolve <task-file> <current-harness> <workspace> <plan-id> <task-id>
 ```
+
+Resolvers never launch external processes. After interpreting all route results, issue
+all `external-override` executions and all native Task-tool agents **together in one
+parallel tool operation**. External execution uses:
+
+```text
+scripts/dispatch-task-execution.cjs execute <task-file> <current-harness> <workspace> <plan-id> <task-id>
+```
+
+This two-step protocol is mandatory: do not execute external tasks during route
+resolution, do not serialize external commands, and do not wait for external completion
+before launching ready native agents. If an execute-time pre-flight returns `fallback`,
+record its reason and immediately launch the ordinary native path without override prose.
 
 `<current-harness>` is the exact supported harness identifier running this
 skill and `<workspace>` is the project working directory. Interpret its JSON
@@ -101,7 +115,11 @@ reasoning-effort prose only when returned; `fallback` visibly records its
 reason then uses ordinary native dispatch with no override prose;
 `launched-success` has already completed externally and receives normal status
 and evidence review; `launched-failure` is a failed task and must enter the
-existing error-hook/status path without any native retry.
+existing error-hook/status path without any native retry; `infrastructure-failure`
+is also a failed task, must be marked failed, and must run
+`<root>/config/hooks/POST_ERROR_DETECTION.md` without native retry. The command
+always emits exactly one JSON line; exit code `2` identifies entrypoint/infrastructure
+failure while exit code `1` identifies a launched task failure.
 
 Deploy all remaining native agents simultaneously using your internal Task tool. Each agent MUST:
 

--- a/templates/harness/skills/st-execute-task/SKILL.md
+++ b/templates/harness/skills/st-execute-task/SKILL.md
@@ -136,8 +136,32 @@ Preserve all other frontmatter fields exactly.
 
 ### 8. Execute the task
 
-Deploy an agent using your internal Task tool. The agent MUST perform these
-steps in order:
+Before deploying a native agent, consult the bundled policy/dispatch runtime:
+
+```text
+scripts/dispatch-task-execution.cjs <task-file> <current-harness> <workspace> <plan-id> <task-id>
+```
+
+`<current-harness>` is the exact supported harness identifier running this
+skill; `<workspace>` is the project working directory. Read the one-line JSON
+result and act exactly once:
+
+- `native-default`: use the ordinary native Task dispatch below with no
+  execution-setting prose.
+- `native-override`: use native dispatch and explicitly require the subagent
+  to use the exact returned `model`. Mention `reasoningEffort` only when that
+  property is present.
+- `fallback`: visibly record the returned reason and detail, then use ordinary
+  native dispatch with no execution-setting prose. This is a pre-launch
+  fallback only.
+- `launched-success`: the external harness has completed the task; do not
+  dispatch a native agent. Continue directly with status and evidence review.
+- `launched-failure` (the script exits 1): treat it as an execution failure.
+  Do not dispatch or retry natively; follow steps 9–11's failed-status and
+  error-hook path.
+
+For either native dispatch outcome, deploy an agent using your internal Task
+tool. The agent MUST perform these steps in order:
 
 1. **Pre-flight validation**: Read and execute
    `<root>/config/hooks/PRE_TASK_EXECUTION.md` before starting any

--- a/templates/harness/skills/st-full-workflow/SKILL.md
+++ b/templates/harness/skills/st-full-workflow/SKILL.md
@@ -403,11 +403,25 @@ Read `<root>/config/hooks/PRE_PHASE.md` and execute its instructions before star
 ##### 5b. Task dispatch
 Identify all tasks scheduled for this phase whose dependencies are fully satisfied. Read `<root>/config/hooks/PRE_TASK_ASSIGNMENT.md` and follow its instructions for agent selection before dispatching tasks.
 
-For each selected task, before native dispatch run:
+Resolve every selected task's execution route first. Invoke one resolver per selected
+task simultaneously in a single parallel tool operation:
 
 ```text
-scripts/dispatch-task-execution.cjs <task-file> <current-harness> <workspace> <plan-id> <task-id>
+scripts/dispatch-task-execution.cjs resolve <task-file> <current-harness> <workspace> <plan-id> <task-id>
 ```
+
+Resolvers never launch external processes. After interpreting all route results, issue
+all `external-override` executions and all native Task-tool agents **together in one
+parallel tool operation**. External execution uses:
+
+```text
+scripts/dispatch-task-execution.cjs execute <task-file> <current-harness> <workspace> <plan-id> <task-id>
+```
+
+This two-step protocol is mandatory: do not execute external tasks during route
+resolution, do not serialize external commands, and do not wait for external completion
+before launching ready native agents. If an execute-time pre-flight returns `fallback`,
+record its reason and immediately launch the ordinary native path without override prose.
 
 `<current-harness>` is the exact supported harness identifier running this
 skill and `<workspace>` is the project working directory. Interpret its JSON
@@ -417,7 +431,11 @@ reasoning-effort prose only when returned; `fallback` visibly records its
 reason then uses ordinary native dispatch with no override prose;
 `launched-success` has already completed externally and receives normal status
 and evidence review; `launched-failure` is a failed task and must enter the
-existing error-hook/status path without any native retry.
+existing error-hook/status path without any native retry; `infrastructure-failure`
+is also a failed task, must be marked failed, and must run
+`<root>/config/hooks/POST_ERROR_DETECTION.md` without native retry. The command
+always emits exactly one JSON line; exit code `2` identifies entrypoint/infrastructure
+failure while exit code `1` identifies a launched task failure.
 
 Deploy all remaining native agents simultaneously using your internal Task tool. Each agent MUST:
 

--- a/templates/harness/skills/st-full-workflow/SKILL.md
+++ b/templates/harness/skills/st-full-workflow/SKILL.md
@@ -290,6 +290,10 @@ Optional frontmatter:
 - `complexity_notes` (string) — include when the score needs justification,
   such as "Decomposed from a cross-cutting parent task" or "Ambiguous API
   contract".
+- `execution` (mapping) — a task-only execution override. When present,
+  `model` is required and must be an exact string. `reasoning_effort` and a
+  different external `harness` are optional. Do not create plan defaults,
+  inheritance, aliases, model discovery, or model-name translation.
 
 The body sections (Objective, Skills Required, Acceptance Criteria, Technical
 Requirements, Input Dependencies, Output Artifacts, Implementation Notes)
@@ -399,7 +403,23 @@ Read `<root>/config/hooks/PRE_PHASE.md` and execute its instructions before star
 ##### 5b. Task dispatch
 Identify all tasks scheduled for this phase whose dependencies are fully satisfied. Read `<root>/config/hooks/PRE_TASK_ASSIGNMENT.md` and follow its instructions for agent selection before dispatching tasks.
 
-Deploy all selected agents simultaneously using your internal Task tool. Each agent MUST:
+For each selected task, before native dispatch run:
+
+```text
+scripts/dispatch-task-execution.cjs <task-file> <current-harness> <workspace> <plan-id> <task-id>
+```
+
+`<current-harness>` is the exact supported harness identifier running this
+skill and `<workspace>` is the project working directory. Interpret its JSON
+result before choosing a route: `native-default` uses ordinary native dispatch;
+`native-override` uses native dispatch with explicit exact-model prose and
+reasoning-effort prose only when returned; `fallback` visibly records its
+reason then uses ordinary native dispatch with no override prose;
+`launched-success` has already completed externally and receives normal status
+and evidence review; `launched-failure` is a failed task and must enter the
+existing error-hook/status path without any native retry.
+
+Deploy all remaining native agents simultaneously using your internal Task tool. Each agent MUST:
 
 1. Read and execute `<root>/config/hooks/PRE_TASK_EXECUTION.md` before starting any implementation work.
 2. Execute the task according to its requirements.

--- a/templates/harness/skills/st-generate-tasks/SKILL.md
+++ b/templates/harness/skills/st-generate-tasks/SKILL.md
@@ -232,6 +232,10 @@ Optional frontmatter:
 - `complexity_notes` (string) — include when the score needs justification,
   such as "Decomposed from a cross-cutting parent task" or "Ambiguous API
   contract".
+- `execution` (mapping) — a task-only execution override. When present,
+  `model` is required and must be an exact string. `reasoning_effort` and a
+  different external `harness` are optional. Do not create plan defaults,
+  inheritance, aliases, model discovery, or model-name translation.
 
 The body sections (Objective, Skills Required, Acceptance Criteria, Technical
 Requirements, Input Dependencies, Output Artifacts, Implementation Notes)

--- a/templates/strikethroo/config/templates/TASK_TEMPLATE.md
+++ b/templates/strikethroo/config/templates/TASK_TEMPLATE.md
@@ -8,6 +8,12 @@ skills: # Technical skills required for this task
   - [SKILL-1]
   - [SKILL-2]
 complexity_score: [1-10]  # Required on every newly generated task
+# Optional task-only execution override. `model` is required and passed unchanged.
+# execution:
+#   model: "exact-provider-model-id"
+#   reasoning_effort: high
+#   harness: copilot # Must differ from the current orchestrator.
+# No plan defaults, inheritance, aliases, model discovery, or name translation.
 ---
 # [TASK-TITLE]
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
       'src/__tests__/cli.integration.test.ts',
       'src/__tests__/config-write.test.ts',
       'src/__tests__/conflict-detection.integration.test.ts',
+      'src/__tests__/execution-policy.test.ts',
+      'src/__tests__/external-dispatch.test.ts',
       'src/__tests__/self-review.test.ts',
       'src/__tests__/serve-archive.integration.test.ts',
       'src/__tests__/serve-server.integration.test.ts',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       'src/__tests__/cli.integration.test.ts',
       'src/__tests__/config-write.test.ts',
       'src/__tests__/conflict-detection.integration.test.ts',
+      'src/__tests__/dispatch-task-execution.integration.test.ts',
       'src/__tests__/execution-policy.test.ts',
       'src/__tests__/external-dispatch.test.ts',
       'src/__tests__/self-review.test.ts',


### PR DESCRIPTION
## Summary
- replace the `github` harness identifier with `copilot` and generate Copilot custom agents at `.github/agents/*.md`
- add task-only `execution` frontmatter parsing, including exact model pass-through and lossless status rewriting
- add a bundled external-dispatch runtime for Claude, Codex, Cursor, Gemini, Copilot, and OpenCode
- integrate native overrides, pre-launch fallback, external dispatch, and committed launched-failure behavior into execution skill guidance

## Safety and behavior
- command builders use executable plus argv, never shell interpolation
- unavailable executables, failed authentication, and unsupported reasoning effort fall back before launch
- nonzero external process exits remain task failures and do not trigger native retries
- no model aliases, discovery, normalization, plan defaults, or inheritance

## Verification
- `npm run build`
- `npm test` — 232 unit tests and 36 Playwright tests passed
- Playwright also passed with `--workers=2`, used as the stable retry after one default-worker CPU-contention timeout
