### PR TITLE
feat: introduce manifest-driven harness adapter registry

### DIFF
--- a/src/__tests__/harness-registry.test.ts
+++ b/src/__tests__/harness-registry.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Harness Adapter Registry Tests
+ *
+ * Integration-first: exercises the registry against the real filesystem and the
+ * real agent templates, since the whole point of an adapter is what it writes to
+ * disk. Covers registry membership and the detect/install/update lifecycle.
+ */
+
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+import { HarnessRegistry } from '../harnesses';
+import { SUPPORTED_HARNESSES } from '../types';
+import { getAgentFormat } from '../utils';
+
+describe('HarnessRegistry', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'st-harness-registry-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  it('registers exactly one adapter per supported harness', () => {
+    expect(new Set(HarnessRegistry.keys())).toEqual(new Set(SUPPORTED_HARNESSES));
+    for (const harness of SUPPORTED_HARNESSES) {
+      expect(HarnessRegistry.get(harness)?.id).toBe(harness);
+    }
+  });
+
+  it('install creates the harness agent files for a markdown harness', async () => {
+    const created = await HarnessRegistry.get('claude')!.install(tempDir);
+
+    const agentPath = path.join(tempDir, '.claude/agents/plan-creator.md');
+    expect(await fs.pathExists(agentPath)).toBe(true);
+    expect(created).toContain(agentPath);
+  });
+
+  it('install converts to TOML for codex', async () => {
+    await HarnessRegistry.get('codex')!.install(tempDir);
+
+    const tomlPath = path.join(tempDir, '.codex/agents/plan-creator.toml');
+    expect(await fs.pathExists(tomlPath)).toBe(true);
+    const contents = await fs.readFile(tomlPath, 'utf-8');
+    expect(contents).toContain('developer_instructions = """');
+  });
+
+  it('detect is false before install and true after', async () => {
+    const adapter = HarnessRegistry.get('gemini')!;
+    expect(await adapter.detect(tempDir)).toBe(false);
+
+    await adapter.install(tempDir);
+    expect(await adapter.detect(tempDir)).toBe(true);
+
+    const agentDir = path.join(tempDir, getAgentFormat('gemini').directory);
+    expect(await fs.pathExists(agentDir)).toBe(true);
+  });
+
+  it('update is idempotent and rewrites the same files as install', async () => {
+    const adapter = HarnessRegistry.get('claude')!;
+    const installed = await adapter.install(tempDir);
+    const updated = await adapter.update(tempDir);
+
+    expect(updated).toEqual(installed);
+    for (const file of updated) {
+      expect(await fs.pathExists(file)).toBe(true);
+    }
+  });
+});

--- a/src/harnesses/agent-adapter.ts
+++ b/src/harnesses/agent-adapter.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared Agent Harness Adapter
+ *
+ * Every harness Strikethroo currently supports installs the same way: copy the
+ * agent templates from `templates/harness/agents/`, converting to Codex's TOML
+ * format where required. Rather than hand-write six near-identical adapters, a
+ * single factory produces one per harness, parameterized by the existing
+ * `getAgentFormat` descriptor.
+ *
+ * Importing this module has the side effect of registering an adapter for every
+ * entry in `SUPPORTED_HARNESSES`.
+ */
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { Harness, SUPPORTED_HARNESSES } from '../types';
+import { getAgentFormat, convertAgentMdToToml } from '../utils';
+import { HarnessAdapter, registerHarnessAdapter } from './registry';
+
+/**
+ * Absolute path to the shared agent templates directory.
+ *
+ * Resolved relative to this compiled module: `dist/harnesses/agent-adapter.js`
+ * sits two levels below the package root that holds `templates/`.
+ */
+function getAgentsTemplateDir(): string {
+  return path.join(__dirname, '..', '..', 'templates', 'harness', 'agents');
+}
+
+/** Resolve the target agent directory for a harness under a project root. */
+function agentDirFor(harness: Harness, projectRoot: string): string {
+  return path.resolve(projectRoot || '.', getAgentFormat(harness).directory);
+}
+
+/**
+ * Write the agent files for a harness under `projectRoot`, overwriting any
+ * existing files. Returns the absolute paths written. Shared by `install` and
+ * `update` — the operation is idempotent.
+ */
+async function writeAgentFiles(harness: Harness, projectRoot: string): Promise<string[]> {
+  const sourceAgentsDir = getAgentsTemplateDir();
+  if (!(await fs.pathExists(sourceAgentsDir))) {
+    return [];
+  }
+
+  const agentFiles = (await fs.readdir(sourceAgentsDir)).filter(f => f.endsWith('.md'));
+  const formatInfo = getAgentFormat(harness);
+  const targetDir = agentDirFor(harness, projectRoot);
+  await fs.ensureDir(targetDir);
+
+  const writtenFiles: string[] = [];
+  for (const agentFile of agentFiles) {
+    const sourcePath = path.join(sourceAgentsDir, agentFile);
+    const content = await fs.readFile(sourcePath, 'utf-8');
+    const baseName = path.basename(agentFile, '.md');
+    const targetPath = path.join(targetDir, baseName + formatInfo.extension);
+
+    if (formatInfo.format === 'toml') {
+      await fs.writeFile(targetPath, convertAgentMdToToml(content), 'utf-8');
+    } else {
+      await fs.writeFile(targetPath, content, 'utf-8');
+    }
+
+    writtenFiles.push(targetPath);
+  }
+
+  return writtenFiles;
+}
+
+/**
+ * Build a {@link HarnessAdapter} for a harness whose install mechanism is the
+ * shared agent-file copy.
+ */
+export function createAgentAdapter(id: Harness): HarnessAdapter {
+  return {
+    id,
+    async detect(projectRoot: string): Promise<boolean> {
+      return fs.pathExists(agentDirFor(id, projectRoot));
+    },
+    async install(projectRoot: string): Promise<string[]> {
+      return writeAgentFiles(id, projectRoot);
+    },
+    async update(projectRoot: string): Promise<string[]> {
+      return writeAgentFiles(id, projectRoot);
+    },
+  };
+}
+
+// Register an adapter for every supported harness.
+for (const harness of SUPPORTED_HARNESSES) {
+  registerHarnessAdapter(createAgentAdapter(harness));
+}

--- a/src/harnesses/index.ts
+++ b/src/harnesses/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Harness Registry Barrel
+ *
+ * Importing this module guarantees the registry is populated: it pulls in the
+ * agent adapter module for its registration side effect, then re-exports the
+ * registry surface. Consumers should import from here, not from the individual
+ * modules, so the adapters are always registered before use.
+ */
+
+import './agent-adapter';
+
+export { HarnessRegistry, registerHarnessAdapter } from './registry';
+export type { HarnessAdapter } from './registry';
+export { createAgentAdapter } from './agent-adapter';

--- a/src/harnesses/registry.ts
+++ b/src/harnesses/registry.ts
@@ -1,0 +1,40 @@
+/**
+ * Harness Adapter Registry
+ *
+ * A minimal, single extension point describing how each supported harness is
+ * detected, installed, and updated. `init` iterates the registry instead of
+ * branching over harnesses.
+ *
+ * Deliberately small: no profiles, no delivery-strategy abstraction, and no
+ * per-tool config schema — just "one place to register a harness".
+ */
+
+import { Harness } from '../types';
+
+/**
+ * Describes the lifecycle of a single harness.
+ *
+ * All paths are resolved against `projectRoot`. `install` and `update` return
+ * the absolute paths of the files they wrote.
+ */
+export interface HarnessAdapter {
+  /** The harness this adapter manages. */
+  id: Harness;
+  /** Resolve to `true` when the harness is already present under `projectRoot`. */
+  detect(projectRoot: string): Promise<boolean>;
+  /** Create the harness's files under `projectRoot`; resolve to the paths written. */
+  install(projectRoot: string): Promise<string[]>;
+  /** Re-apply the harness's files (idempotent); resolve to the paths written. */
+  update(projectRoot: string): Promise<string[]>;
+}
+
+/** The single registry of harness adapters, keyed by harness id. */
+export const HarnessRegistry = new Map<Harness, HarnessAdapter>();
+
+/**
+ * Register an adapter, keyed by its `id`. Later registrations for the same id
+ * replace earlier ones.
+ */
+export function registerHarnessAdapter(adapter: HarnessAdapter): void {
+  HarnessRegistry.set(adapter.id, adapter);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import chalk from 'chalk';
-import { InitOptions, Harness, CommandResult, ConflictResolution, InitMetadata } from './types';
-import { parseHarnesses, validateHarnesses, getAgentFormat, convertAgentMdToToml } from './utils';
+import { InitOptions, CommandResult, ConflictResolution, InitMetadata } from './types';
+import { parseHarnesses, validateHarnesses } from './utils';
 import {
   calculateFileHash,
   loadMetadata,
@@ -19,6 +19,7 @@ import {
 } from './metadata';
 import { detectConflicts } from './conflict-detector';
 import { promptForConflicts } from './prompts';
+import { HarnessRegistry } from './harnesses';
 
 // Visual formatting constants
 const TERM_WIDTH = 80;
@@ -125,11 +126,15 @@ export async function init(options: InitOptions): Promise<CommandResult> {
     console.log(`  ${chalk.green('✓')} Copying common template files`);
     await copyCommonTemplates(baseDir, options.force || false);
 
-    // Create harness-specific directories and copy templates
+    // Create harness-specific directories and copy templates via the registry
     const allCreatedAgentFiles: Map<string, string[]> = new Map();
     for (const harness of harnesses) {
       console.log(`  ${chalk.green('✓')} Setting up ${harness} harness configuration`);
-      const created = await createHarnessStructure(harness, baseDir);
+      const adapter = HarnessRegistry.get(harness);
+      if (!adapter) {
+        throw new Error(`No registered harness adapter for: ${harness}`);
+      }
+      const created = await adapter.install(baseDir);
       if (created.length > 0) {
         allCreatedAgentFiles.set(harness, created);
       }
@@ -316,38 +321,6 @@ async function applyResolutions(
     }
     // If 'keep', do nothing - keep user's file
   }
-}
-
-async function createHarnessStructure(harness: Harness, baseDir: string): Promise<string[]> {
-  const sourceAgentsDir = getTemplatePath(path.join('harness', 'agents'));
-  const createdFiles: string[] = [];
-
-  if (!(await exists(sourceAgentsDir))) {
-    return createdFiles;
-  }
-
-  const agentFiles = (await fs.readdir(sourceAgentsDir)).filter(f => f.endsWith('.md'));
-  const formatInfo = getAgentFormat(harness);
-  const targetDir = resolvePath(baseDir, formatInfo.directory);
-  await fs.ensureDir(targetDir);
-
-  for (const agentFile of agentFiles) {
-    const sourcePath = path.join(sourceAgentsDir, agentFile);
-    const content = await fs.readFile(sourcePath, 'utf-8');
-    const baseName = path.basename(agentFile, '.md');
-    const targetName = baseName + formatInfo.extension;
-    const targetPath = path.join(targetDir, targetName);
-
-    if (formatInfo.format === 'toml') {
-      await fs.writeFile(targetPath, convertAgentMdToToml(content), 'utf-8');
-    } else {
-      await fs.writeFile(targetPath, content, 'utf-8');
-    }
-
-    createdFiles.push(targetPath);
-  }
-
-  return createdFiles;
 }
 
 /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       'src/__tests__/dispatch-task-execution.integration.test.ts',
       'src/__tests__/execution-policy.test.ts',
       'src/__tests__/external-dispatch.test.ts',
+      'src/__tests__/harness-registry.test.ts',
       'src/__tests__/self-review.test.ts',
       'src/__tests__/serve-archive.integration.test.ts',
       'src/__tests__/serve-server.integration.test.ts',
@@ -31,12 +32,7 @@ export default defineConfig({
       'src/web/plans/exec/__tests__/derive.test.ts',
       'src/web/theme/__tests__/theme.test.ts',
     ],
-    exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/dist-web/**',
-      'src/__tests__/*.e2e.test.ts',
-    ],
+    exclude: ['**/node_modules/**', '**/dist/**', '**/dist-web/**', 'src/__tests__/*.e2e.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary'],


### PR DESCRIPTION
Extract the per-harness init logic that lived inline in src/index.ts into a
small adapter registry under src/harnesses/. Each supported harness is now a
HarnessAdapter that declares how it is detected, installed, and updated, and
init iterates HarnessRegistry instead of branching over harnesses.

Because every supported harness installs the same way (copy the agent
templates, converting to TOML for Codex), the adapters are produced by a single
createAgentAdapter factory backed by the existing getAgentFormat descriptor,
keeping the registry to one obvious extension point without profiles, a
delivery-strategy abstraction, or a per-tool config schema.

The change is a pure internal refactor: init's observable behavior, console
output, and created files are unchanged, so the existing init integration suite
passes unmodified. detect() and update() are provided for interface
completeness; init behavior is unchanged (detect is not wired into its control
flow).

Closes #30

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019Lc25v7i8wz1HqLNXbhapq