### PR TITLE
fix: allow workspace-only branch creation

### DIFF
--- a/src/__tests__/skill-scripts.test.ts
+++ b/src/__tests__/skill-scripts.test.ts
@@ -362,7 +362,29 @@ describe('create-feature-branch integration', () => {
     expect(result).toContain('Proceeding without creating a new branch');
   });
 
-  test('errors when uncommitted changes exist on main', () => {
+  test('creates a feature branch when changes are confined to .ai/strikethroo', () => {
+    const planFile = buildGitFixture(tempDir, 'my-test-plan', 42);
+    writeFile(
+      path.join(tempDir, '.ai', 'strikethroo', 'plans', '42--my-test-plan', 'tasks', '01--task.md'),
+      'generated task'
+    );
+    const bundledScript = path.join(
+      REPO_ROOT,
+      'templates',
+      'harness',
+      'skills',
+      'st-execute-blueprint',
+      'scripts',
+      'create-feature-branch.cjs'
+    );
+    const result = execFileSync('node', [bundledScript, planFile], {
+      cwd: tempDir,
+      encoding: 'utf8',
+    });
+    expect(result).toContain('Created and switched to branch: feature/42--my-test-plan');
+  });
+
+  test('errors when uncommitted changes outside .ai/strikethroo exist on main', () => {
     const planFile = buildGitFixture(tempDir, 'my-test-plan', 42);
     fs.writeFileSync(path.join(tempDir, 'dirty.txt'), 'dirty');
     const bundledScript = path.join(

--- a/src/__tests__/skill-scripts.test.ts
+++ b/src/__tests__/skill-scripts.test.ts
@@ -12,7 +12,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 
 import { findStrikethrooRoot } from '../skill-scripts/shared/root';
 import { getAllPlans, computeNextPlanId } from '../skill-scripts/shared/plan-scan';
@@ -276,6 +276,16 @@ describe('create-feature-branch helpers', () => {
 describe('create-feature-branch integration', () => {
   let tempDir: string;
 
+  const bundledScript = path.join(
+    REPO_ROOT,
+    'templates',
+    'harness',
+    'skills',
+    'st-execute-blueprint',
+    'scripts',
+    'create-feature-branch.cjs'
+  );
+
   const buildGitFixture = (root: string, planName: string, planId: number): string => {
     const tm = path.join(root, '.ai', 'strikethroo');
     fs.mkdirSync(tm, { recursive: true });
@@ -290,18 +300,12 @@ describe('create-feature-branch integration', () => {
       planFile,
       `---\nid: ${planId}\nsummary: "${planName}"\ncreated: 2026-01-01\n---\n`
     );
-    execFileSync('git', ['init', '-b', 'main'], {
-      cwd: root,
-      stdio: 'pipe',
-    });
+    execFileSync('git', ['init', '-b', 'main'], { cwd: root, stdio: 'pipe' });
     execFileSync('git', ['config', 'user.email', 'test@test.com'], {
       cwd: root,
       stdio: 'pipe',
     });
-    execFileSync('git', ['config', 'user.name', 'Test'], {
-      cwd: root,
-      stdio: 'pipe',
-    });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: root, stdio: 'pipe' });
     fs.writeFileSync(path.join(root, 'init.txt'), 'init');
     execFileSync('git', ['add', '.'], { cwd: root, stdio: 'pipe' });
     execFileSync('git', ['commit', '-m', 'init'], { cwd: root, stdio: 'pipe' });
@@ -316,27 +320,34 @@ describe('create-feature-branch integration', () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
+  const runScript = (
+    planFile: string,
+    cwd: string = tempDir,
+    env: Record<string, string | undefined> = process.env
+  ) => {
+    const result = spawnSync('node', [bundledScript, planFile], {
+      cwd,
+      encoding: 'utf8',
+      env,
+    });
+    return {
+      status: result.status,
+      output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+    };
+  };
+
+  const currentBranch = (): string =>
+    execFileSync('git', ['branch', '--show-current'], {
+      cwd: tempDir,
+      encoding: 'utf8',
+    }).trim();
+
   test('creates feature branch from clean main', () => {
     const planFile = buildGitFixture(tempDir, 'my-test-plan', 42);
-    const bundledScript = path.join(
-      REPO_ROOT,
-      'templates',
-      'harness',
-      'skills',
-      'st-execute-blueprint',
-      'scripts',
-      'create-feature-branch.cjs'
-    );
-    const result = execFileSync('node', [bundledScript, planFile], {
-      cwd: tempDir,
-      encoding: 'utf8',
-    });
-    expect(result).toContain('Created and switched to branch: feature/42--my-test-plan');
-    const branches = execFileSync('git', ['branch', '--list'], {
-      cwd: tempDir,
-      encoding: 'utf8',
-    });
-    expect(branches).toContain('feature/42--my-test-plan');
+    const result = runScript(planFile);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('Created and switched to branch: feature/42--my-test-plan');
+    expect(currentBranch()).toBe('feature/42--my-test-plan');
   });
 
   test('skips branch creation when not on main', () => {
@@ -345,67 +356,117 @@ describe('create-feature-branch integration', () => {
       cwd: tempDir,
       stdio: 'pipe',
     });
-    const bundledScript = path.join(
-      REPO_ROOT,
-      'templates',
-      'harness',
-      'skills',
-      'st-execute-blueprint',
-      'scripts',
-      'create-feature-branch.cjs'
-    );
-    const result = execFileSync('node', [bundledScript, planFile], {
+    const result = runScript(planFile);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('Not on main/master branch');
+    expect(result.output).toContain('Proceeding without creating a new branch');
+  });
+
+  test('creates a feature branch without modifying staged or unstaged workspace state', () => {
+    const planFile = buildGitFixture(tempDir, 'my-test-plan', 42);
+    fs.appendFileSync(planFile, 'workspace edit\n');
+    execFileSync('git', ['add', planFile], { cwd: tempDir, stdio: 'pipe' });
+    const taskFile = path.join(path.dirname(planFile), 'tasks', '01--task.md');
+    writeFile(taskFile, 'generated task');
+    const statusBefore = execFileSync('git', ['status', '--porcelain'], {
       cwd: tempDir,
       encoding: 'utf8',
     });
-    expect(result).toContain('Not on main/master branch');
-    expect(result).toContain('Proceeding without creating a new branch');
+    const planBefore = fs.readFileSync(planFile, 'utf8');
+
+    const result = runScript(planFile);
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('Created and switched to branch: feature/42--my-test-plan');
+    expect(currentBranch()).toBe('feature/42--my-test-plan');
+    expect(execFileSync('git', ['status', '--porcelain'], { cwd: tempDir, encoding: 'utf8' })).toBe(
+      statusBefore
+    );
+    expect(fs.readFileSync(planFile, 'utf8')).toBe(planBefore);
+    expect(fs.readFileSync(taskFile, 'utf8')).toBe('generated task');
   });
 
-  test('creates a feature branch when changes are confined to .ai/strikethroo', () => {
+  test.each([
+    [
+      'tracked modification',
+      (root: string) => fs.writeFileSync(path.join(root, 'init.txt'), 'changed'),
+    ],
+    ['tracked deletion', (root: string) => fs.rmSync(path.join(root, 'init.txt'))],
+    [
+      'staged modification',
+      (root: string) => {
+        fs.writeFileSync(path.join(root, 'init.txt'), 'staged');
+        execFileSync('git', ['add', 'init.txt'], { cwd: root, stdio: 'pipe' });
+      },
+    ],
+    [
+      'rename',
+      (root: string) =>
+        execFileSync('git', ['mv', 'init.txt', 'renamed.txt'], { cwd: root, stdio: 'pipe' }),
+    ],
+    ['untracked file', (root: string) => fs.writeFileSync(path.join(root, 'dirty.txt'), 'dirty')],
+  ])('blocks an outside-workspace %s on main', (_state, makeDirty) => {
     const planFile = buildGitFixture(tempDir, 'my-test-plan', 42);
+    makeDirty(tempDir);
+
+    const result = runScript(planFile);
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain('Uncommitted changes detected outside .ai/strikethroo');
+    expect(result.output).toContain('Commit or stash changes outside .ai/strikethroo');
+    expect(currentBranch()).toBe('main');
+  });
+
+  test('blocks repository-root dirt when invoked from a nested workspace directory', () => {
+    const planFile = buildGitFixture(tempDir, 'my-test-plan', 42);
+    fs.writeFileSync(path.join(tempDir, 'dirty.txt'), 'outside workspace');
+
+    const result = runScript(planFile, path.dirname(planFile));
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain('Uncommitted changes detected outside .ai/strikethroo');
+    expect(currentBranch()).toBe('main');
+  });
+
+  test('allows root-workspace-only dirt when invoked from a nested workspace directory', () => {
+    const planFile = buildGitFixture(tempDir, 'my-test-plan', 42);
+    const taskFile = path.join(path.dirname(planFile), 'tasks', '01--task.md');
+    writeFile(taskFile, 'generated task');
+    const statusBefore = execFileSync('git', ['status', '--porcelain'], {
+      cwd: tempDir,
+      encoding: 'utf8',
+    });
+
+    const result = runScript(planFile, path.dirname(planFile));
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('Created and switched to branch: feature/42--my-test-plan');
+    expect(currentBranch()).toBe('feature/42--my-test-plan');
+    expect(execFileSync('git', ['status', '--porcelain'], { cwd: tempDir, encoding: 'utf8' })).toBe(
+      statusBefore
+    );
+    expect(fs.readFileSync(taskFile, 'utf8')).toBe('generated task');
+  });
+
+  test('fails closed and leaves main unchanged when Git status inspection fails', () => {
+    const planFile = buildGitFixture(tempDir, 'my-test-plan', 42);
+    const realGit = execFileSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).trim();
+    const fakeBin = path.join(tempDir, 'fake-bin');
+    const fakeGit = path.join(fakeBin, 'git');
     writeFile(
-      path.join(tempDir, '.ai', 'strikethroo', 'plans', '42--my-test-plan', 'tasks', '01--task.md'),
-      'generated task'
+      fakeGit,
+      `#!/bin/sh\nif [ "$1" = "status" ]; then\n  echo "simulated status failure" >&2\n  exit 2\nfi\nexec "${realGit}" "$@"\n`
     );
-    const bundledScript = path.join(
-      REPO_ROOT,
-      'templates',
-      'harness',
-      'skills',
-      'st-execute-blueprint',
-      'scripts',
-      'create-feature-branch.cjs'
-    );
-    const result = execFileSync('node', [bundledScript, planFile], {
-      cwd: tempDir,
-      encoding: 'utf8',
-    });
-    expect(result).toContain('Created and switched to branch: feature/42--my-test-plan');
-  });
+    fs.chmodSync(fakeGit, 0o755);
 
-  test('errors when uncommitted changes outside .ai/strikethroo exist on main', () => {
-    const planFile = buildGitFixture(tempDir, 'my-test-plan', 42);
-    fs.writeFileSync(path.join(tempDir, 'dirty.txt'), 'dirty');
-    const bundledScript = path.join(
-      REPO_ROOT,
-      'templates',
-      'harness',
-      'skills',
-      'st-execute-blueprint',
-      'scripts',
-      'create-feature-branch.cjs'
-    );
-    let exitCode: number | null = null;
-    try {
-      execFileSync('node', [bundledScript, planFile], {
-        cwd: tempDir,
-        encoding: 'utf8',
-      });
-    } catch (e: any) {
-      exitCode = e.status ?? null;
-    }
-    expect(exitCode).toBe(1);
+    const result = runScript(planFile, tempDir, {
+      ...process.env,
+      PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ''}`,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain('Could not inspect git status');
+    expect(currentBranch()).toBe('main');
   });
 
   test('checks out existing branch when on main', () => {
@@ -415,26 +476,11 @@ describe('create-feature-branch integration', () => {
       stdio: 'pipe',
     });
     execFileSync('git', ['checkout', 'main'], { cwd: tempDir, stdio: 'pipe' });
-    const bundledScript = path.join(
-      REPO_ROOT,
-      'templates',
-      'harness',
-      'skills',
-      'st-execute-blueprint',
-      'scripts',
-      'create-feature-branch.cjs'
-    );
-    const result = execFileSync('node', [bundledScript, planFile], {
-      cwd: tempDir,
-      encoding: 'utf8',
-    });
-    expect(result).toContain('already exists');
-    expect(result).toContain('Switched to existing branch: feature/42--my-test-plan');
-    const currentBranch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
-      cwd: tempDir,
-      encoding: 'utf8',
-    }).trim();
-    expect(currentBranch).toBe('feature/42--my-test-plan');
+    const result = runScript(planFile);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('already exists');
+    expect(result.output).toContain('Switched to existing branch: feature/42--my-test-plan');
+    expect(currentBranch()).toBe('feature/42--my-test-plan');
   });
 });
 

--- a/src/skill-prompts/st-execute-blueprint.md
+++ b/src/skill-prompts/st-execute-blueprint.md
@@ -52,7 +52,7 @@ If generation still leaves the plan without tasks or a blueprint, stop and repor
 
 ### 5. Optionally create a feature branch
 
-Run `scripts/create-feature-branch.cjs <plan-id>` once before phase execution. Branch creation is best-effort: when the script reports that it skipped creation (for example, not on `main`/`master`), continue on the current branch and do not retry or create a branch manually. Uncommitted or untracked changes confined to `.ai/strikethroo` are permitted so a newly generated plan and tasks can remain uncommitted before execution. When the script exits with an error (for example, changes outside `.ai/strikethroo` on `main`/`master`), halt and report the error. Do not treat a skipped branch as a failure or spend effort working around a skip.
+Run `scripts/create-feature-branch.cjs <plan-id>` once before phase execution. Branch creation is best-effort: when the script reports that it skipped creation (for example, not on `main`/`master`), continue on the current branch and do not retry or create a branch manually. Uncommitted or untracked changes are permitted only when every change is inside the repository-root `.ai/strikethroo` subtree, so a newly generated plan and tasks can remain uncommitted before execution. When the script exits with an error—including changes anywhere outside that subtree or an inability to inspect Git status on `main`/`master`—halt and report the error. Do not treat a skipped branch as a failure or spend effort working around a skip.
 
 ### 6. Load project context and execution blueprint
 

--- a/src/skill-prompts/st-execute-blueprint.md
+++ b/src/skill-prompts/st-execute-blueprint.md
@@ -52,7 +52,7 @@ If generation still leaves the plan without tasks or a blueprint, stop and repor
 
 ### 5. Optionally create a feature branch
 
-Run `scripts/create-feature-branch.cjs <plan-id>` once before phase execution. Branch creation is best-effort: when the script reports that it skipped creation (for example, not on `main`/`master`), continue on the current branch and do not retry or create a branch manually. When the script exits with an error (for example, uncommitted changes on `main`/`master`), halt and report the error. Do not treat a skipped branch as a failure or spend effort working around a skip.
+Run `scripts/create-feature-branch.cjs <plan-id>` once before phase execution. Branch creation is best-effort: when the script reports that it skipped creation (for example, not on `main`/`master`), continue on the current branch and do not retry or create a branch manually. Uncommitted or untracked changes confined to `.ai/strikethroo` are permitted so a newly generated plan and tasks can remain uncommitted before execution. When the script exits with an error (for example, changes outside `.ai/strikethroo` on `main`/`master`), halt and report the error. Do not treat a skipped branch as a failure or spend effort working around a skip.
 
 ### 6. Load project context and execution blueprint
 

--- a/src/skill-prompts/st-full-workflow.md
+++ b/src/skill-prompts/st-full-workflow.md
@@ -225,7 +225,7 @@ If `taskCount` is 0 or `blueprintExists` is `no`:
 
 #### 3. Optionally create a feature branch
 
-Run `scripts/create-feature-branch.cjs <plan-id>` once before phase execution. Branch creation is best-effort: when the script reports that it skipped creation (for example, not on `main`/`master`), continue on the current branch and do not retry or create a branch manually. When the script exits with an error (for example, uncommitted changes on `main`/`master`), halt and report the error. Do not treat a skipped branch as a failure or spend effort working around a skip.
+Run `scripts/create-feature-branch.cjs <plan-id>` once before phase execution. Branch creation is best-effort: when the script reports that it skipped creation (for example, not on `main`/`master`), continue on the current branch and do not retry or create a branch manually. Uncommitted or untracked changes confined to `.ai/strikethroo` are permitted so a newly generated plan and tasks can remain uncommitted before execution. When the script exits with an error (for example, changes outside `.ai/strikethroo` on `main`/`master`), halt and report the error. Do not treat a skipped branch as a failure or spend effort working around a skip.
 
 #### 4. Load execution blueprint
 

--- a/src/skill-prompts/st-full-workflow.md
+++ b/src/skill-prompts/st-full-workflow.md
@@ -225,7 +225,7 @@ If `taskCount` is 0 or `blueprintExists` is `no`:
 
 #### 3. Optionally create a feature branch
 
-Run `scripts/create-feature-branch.cjs <plan-id>` once before phase execution. Branch creation is best-effort: when the script reports that it skipped creation (for example, not on `main`/`master`), continue on the current branch and do not retry or create a branch manually. Uncommitted or untracked changes confined to `.ai/strikethroo` are permitted so a newly generated plan and tasks can remain uncommitted before execution. When the script exits with an error (for example, changes outside `.ai/strikethroo` on `main`/`master`), halt and report the error. Do not treat a skipped branch as a failure or spend effort working around a skip.
+Run `scripts/create-feature-branch.cjs <plan-id>` once before phase execution. Branch creation is best-effort: when the script reports that it skipped creation (for example, not on `main`/`master`), continue on the current branch and do not retry or create a branch manually. Uncommitted or untracked changes are permitted only when every change is inside the repository-root `.ai/strikethroo` subtree, so a newly generated plan and tasks can remain uncommitted before execution. When the script exits with an error—including changes anywhere outside that subtree or an inability to inspect Git status on `main`/`master`—halt and report the error. Do not treat a skipped branch as a failure or spend effort working around a skip.
 
 #### 4. Load execution blueprint
 

--- a/src/skill-scripts/create-feature-branch.ts
+++ b/src/skill-scripts/create-feature-branch.ts
@@ -27,10 +27,8 @@ const _getCurrentBranch = (): string | null => {
   return execGit('git rev-parse --abbrev-ref HEAD');
 };
 
-const _hasUncommittedChangesOutsideWorkspace = (): boolean => {
-  const status = execGit("git status --porcelain -- . ':(exclude).ai/strikethroo'");
-  return status !== null && status.length > 0;
-};
+const _getUncommittedChangesOutsideWorkspace = (): string | null =>
+  execGit("git status --porcelain -- ':(top)' ':(top,exclude).ai/strikethroo'");
 
 const _branchExists = (branchName: string): boolean => {
   const localMatch = execGit(`git branch --list "${branchName}"`);
@@ -101,7 +99,13 @@ const main = (startPath: string = process.cwd()): void => {
     process.exit(0);
   }
 
-  if (_hasUncommittedChangesOutsideWorkspace()) {
+  const outsideWorkspaceStatus = _getUncommittedChangesOutsideWorkspace();
+  if (outsideWorkspaceStatus === null) {
+    _printError('Could not inspect git status; branch creation has been blocked');
+    process.exit(1);
+  }
+
+  if (outsideWorkspaceStatus.length > 0) {
     _printError('Uncommitted changes detected outside .ai/strikethroo');
     _printInfo('Commit or stash changes outside .ai/strikethroo before creating a feature branch');
     process.exit(1);

--- a/src/skill-scripts/create-feature-branch.ts
+++ b/src/skill-scripts/create-feature-branch.ts
@@ -27,8 +27,8 @@ const _getCurrentBranch = (): string | null => {
   return execGit('git rev-parse --abbrev-ref HEAD');
 };
 
-const _hasUncommittedChanges = (): boolean => {
-  const status = execGit('git status --porcelain');
+const _hasUncommittedChangesOutsideWorkspace = (): boolean => {
+  const status = execGit("git status --porcelain -- . ':(exclude).ai/strikethroo'");
   return status !== null && status.length > 0;
 };
 
@@ -101,9 +101,9 @@ const main = (startPath: string = process.cwd()): void => {
     process.exit(0);
   }
 
-  if (_hasUncommittedChanges()) {
-    _printError('Uncommitted changes detected in working tree');
-    _printInfo('Please commit or stash your changes before creating a feature branch');
+  if (_hasUncommittedChangesOutsideWorkspace()) {
+    _printError('Uncommitted changes detected outside .ai/strikethroo');
+    _printInfo('Commit or stash changes outside .ai/strikethroo before creating a feature branch');
     process.exit(1);
   }
 

--- a/templates/harness/skills/st-execute-blueprint/SKILL.md
+++ b/templates/harness/skills/st-execute-blueprint/SKILL.md
@@ -64,7 +64,7 @@ If generation still leaves the plan without tasks or a blueprint, stop and repor
 
 ### 5. Optionally create a feature branch
 
-Run `scripts/create-feature-branch.cjs <plan-id>` once before phase execution. Branch creation is best-effort: when the script reports that it skipped creation (for example, not on `main`/`master`), continue on the current branch and do not retry or create a branch manually. Uncommitted or untracked changes confined to `.ai/strikethroo` are permitted so a newly generated plan and tasks can remain uncommitted before execution. When the script exits with an error (for example, changes outside `.ai/strikethroo` on `main`/`master`), halt and report the error. Do not treat a skipped branch as a failure or spend effort working around a skip.
+Run `scripts/create-feature-branch.cjs <plan-id>` once before phase execution. Branch creation is best-effort: when the script reports that it skipped creation (for example, not on `main`/`master`), continue on the current branch and do not retry or create a branch manually. Uncommitted or untracked changes are permitted only when every change is inside the repository-root `.ai/strikethroo` subtree, so a newly generated plan and tasks can remain uncommitted before execution. When the script exits with an error—including changes anywhere outside that subtree or an inability to inspect Git status on `main`/`master`—halt and report the error. Do not treat a skipped branch as a failure or spend effort working around a skip.
 
 ### 6. Load project context and execution blueprint
 

--- a/templates/harness/skills/st-execute-blueprint/SKILL.md
+++ b/templates/harness/skills/st-execute-blueprint/SKILL.md
@@ -64,7 +64,7 @@ If generation still leaves the plan without tasks or a blueprint, stop and repor
 
 ### 5. Optionally create a feature branch
 
-Run `scripts/create-feature-branch.cjs <plan-id>` once before phase execution. Branch creation is best-effort: when the script reports that it skipped creation (for example, not on `main`/`master`), continue on the current branch and do not retry or create a branch manually. When the script exits with an error (for example, uncommitted changes on `main`/`master`), halt and report the error. Do not treat a skipped branch as a failure or spend effort working around a skip.
+Run `scripts/create-feature-branch.cjs <plan-id>` once before phase execution. Branch creation is best-effort: when the script reports that it skipped creation (for example, not on `main`/`master`), continue on the current branch and do not retry or create a branch manually. Uncommitted or untracked changes confined to `.ai/strikethroo` are permitted so a newly generated plan and tasks can remain uncommitted before execution. When the script exits with an error (for example, changes outside `.ai/strikethroo` on `main`/`master`), halt and report the error. Do not treat a skipped branch as a failure or spend effort working around a skip.
 
 ### 6. Load project context and execution blueprint
 

--- a/templates/harness/skills/st-full-workflow/SKILL.md
+++ b/templates/harness/skills/st-full-workflow/SKILL.md
@@ -415,7 +415,7 @@ If `taskCount` is 0 or `blueprintExists` is `no`:
 
 #### 3. Optionally create a feature branch
 
-Run `scripts/create-feature-branch.cjs <plan-id>` once before phase execution. Branch creation is best-effort: when the script reports that it skipped creation (for example, not on `main`/`master`), continue on the current branch and do not retry or create a branch manually. When the script exits with an error (for example, uncommitted changes on `main`/`master`), halt and report the error. Do not treat a skipped branch as a failure or spend effort working around a skip.
+Run `scripts/create-feature-branch.cjs <plan-id>` once before phase execution. Branch creation is best-effort: when the script reports that it skipped creation (for example, not on `main`/`master`), continue on the current branch and do not retry or create a branch manually. Uncommitted or untracked changes confined to `.ai/strikethroo` are permitted so a newly generated plan and tasks can remain uncommitted before execution. When the script exits with an error (for example, changes outside `.ai/strikethroo` on `main`/`master`), halt and report the error. Do not treat a skipped branch as a failure or spend effort working around a skip.
 
 #### 4. Load execution blueprint
 

--- a/templates/harness/skills/st-full-workflow/SKILL.md
+++ b/templates/harness/skills/st-full-workflow/SKILL.md
@@ -415,7 +415,7 @@ If `taskCount` is 0 or `blueprintExists` is `no`:
 
 #### 3. Optionally create a feature branch
 
-Run `scripts/create-feature-branch.cjs <plan-id>` once before phase execution. Branch creation is best-effort: when the script reports that it skipped creation (for example, not on `main`/`master`), continue on the current branch and do not retry or create a branch manually. Uncommitted or untracked changes confined to `.ai/strikethroo` are permitted so a newly generated plan and tasks can remain uncommitted before execution. When the script exits with an error (for example, changes outside `.ai/strikethroo` on `main`/`master`), halt and report the error. Do not treat a skipped branch as a failure or spend effort working around a skip.
+Run `scripts/create-feature-branch.cjs <plan-id>` once before phase execution. Branch creation is best-effort: when the script reports that it skipped creation (for example, not on `main`/`master`), continue on the current branch and do not retry or create a branch manually. Uncommitted or untracked changes are permitted only when every change is inside the repository-root `.ai/strikethroo` subtree, so a newly generated plan and tasks can remain uncommitted before execution. When the script exits with an error—including changes anywhere outside that subtree or an inability to inspect Git status on `main`/`master`—halt and report the error. Do not treat a skipped branch as a failure or spend effort working around a skip.
 
 #### 4. Load execution blueprint
 


### PR DESCRIPTION
## Summary

- Allow `create-feature-branch` to proceed from `main` or `master` when every staged, unstaged, or untracked change is confined to the repository-root `.ai/strikethroo` workspace.
- Preserve the hard safety gate for every change outside that workspace.
- Fail closed when Git status inspection cannot be completed.
- Align the `st-execute-blueprint` and `st-full-workflow` prompts with the executable policy.

## Implementation

The branch script now uses root-anchored Git pathspecs to inspect the complete repository while excluding exactly `:(top,exclude).ai/strikethroo`. This remains correct when the skill is invoked from a nested directory and does not exempt similarly named paths elsewhere.

The status result is handled explicitly: command failure blocks branch creation, while successful empty output is treated as clean. Existing branch naming, non-main behavior, and existing-branch checkout behavior remain unchanged.

## Regression coverage

Real-Git integration cases cover:

- staged and unstaged workspace state, including preservation after checkout;
- outside-workspace tracked modifications and deletions;
- staged changes, renames, and untracked files;
- nested invocation with repository-root dirt;
- nested invocation with workspace-only dirt;
- status-inspection failure;
- existing clean, non-main, and existing-branch behavior.

## Validation

- `npm run lint`
- Focused skill-script suite: **45 passed**
- Full unit/integration gate: **337 passed**
- Full Playwright gate: **37 passed**

Generated CommonJS skill bundles were rebuilt and verified locally but are intentionally excluded from ordinary commits; the release workflow rebuilds and force-adds them.

Fixes #63
