### PR TITLE
docs: reframe messaging around attention and time-to-merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,20 @@ The workflow itself ships as **Agent Skills** (harness-agnostic — one `SKILL.m
 
 This CLI tool initializes AI-assisted development environments with hierarchical task management. It transforms complex programming requests into atomic, validated implementations through staged refinement — managing AI context load, enforcing YAGNI scope control, and ensuring working code through integrity-focused testing.
 
+### Design thesis
+
+Read this before changing anything under `src/skill-prompts/` or `src/skill-scripts/`; most non-obvious decisions in those trees follow from it. User-facing version: [`docs/why.md`](docs/why.md).
+
+Three premises:
+
+1. **The agent is an unreliable narrator of its own work.** A subagent's success report is a claim, not evidence — hence `config/shared/verification-gate.md` and the per-skill anti-rationalization tables, which enumerate *the specific excuses a model generates when about to skip a discipline* rather than giving general advice.
+2. **A second agent reviewing the first is also unreliable.** Hence independent severity/confidence axes with independent floors, fail-safe treatment of absent attributes, the reviewer's own rationalization table, and the `<suggestion>` element's local-text-replacement constraint (a structural block on speculative refactors, not a request for restraint).
+3. **The scarce resource is the user's attention, not tokens.** It is rationed toward the plan, where a correction costs a sentence, and away from the diff, where the same correction costs a review cycle. The automated gate is a filter that runs *before* the user's read — which is why its mandate excludes design and abstraction opinions. Those are what the user's read is preserved for.
+
+The structural consequence, and the invariant to preserve: **negotiable configuration is Markdown; guarantees are compiled.** Hooks, templates, and project context are user-editable Markdown. Termination bounds (`MAX_REVIEW_ROUNDS`), severity/confidence floors, fail-safe defaults, and the reviewer/implementer harness separation live in TypeScript and cannot be loosened by editing a hook. When adding enforcement, decide which side of that line it belongs on and put it there — a bound that a user can raise from a hook is not a bound.
+
+Corollary for "speed": the target metric is **time-to-merge, not time-to-first-draft**. Do not introduce changes that trade merge-readiness for faster generation, and do not describe the project as trading speed for quality — on the time-to-merge clock they are the same number.
+
 ---
 
 ## Strikethroo Plan and Task Management System

--- a/README.md
+++ b/README.md
@@ -114,24 +114,23 @@ flowchart LR
     A[Work Order] --> B[Plan]
     B --> C{Review}
     C -->|Edit| B
-    C -->|Approve| D[Tasks]
-    D --> E{Verify}
-    E --> G[Execute]
+    C -->|Approve| G["Execute<br/>(generates tasks)"]
     G --> H["Code Review<br/>(optional)"]
     H -->|Fix| G
     H -->|Pass| J[Done]
 ```
 
-Four steps, three delivered as Agent Skills that load when you describe what you need:
+**Two commands.** Read the plan, approve it, run it:
 
-| Step        | Skill                           | Output                                            |
-|-------------|---------------------------------|---------------------------------------------------|
-| **Plan**    | `/st-create-plan <your prompt>` | `.ai/strikethroo/plans/64--auth/plan-64--auth.md` |
-| **Tasks**   | `/st-generate-tasks 64`         | `.ai/strikethroo/plans/64--auth/tasks/*.md`       |
-| **Execute** | `/st-execute-blueprint 64`      | Working code, one commit per phase                |
-| **Review**  | Automatic (optional)            | Findings validated against schema; bounded fixes  |
+| Step        | Command                         | Output                                                  |
+|-------------|---------------------------------|---------------------------------------------------------|
+| **Plan**    | `/st-create-plan <your prompt>` | `.ai/strikethroo/plans/64--auth/plan-64--auth.md`       |
+| **Execute** | `/st-execute-blueprint 64`      | Task blueprint, then working code, one commit per phase |
+| **Review**  | Automatic (optional)            | Findings validated against schema; bounded fixes        |
 
-Human review gates between steps catch scope creep before any code is written. Each step runs with clean context -- the planning agent sees only the work order, the task agent sees only the approved plan, and each execution sub-agent receives only its specific task. After execution, an optional automated review gate runs on a discovered second harness, critiques the cumulative diff, and drives bounded remediation if findings exceed configured thresholds.
+`st-execute-blueprint` decomposes the plan into atomic tasks and builds the dependency-mapped blueprint itself when one does not exist yet. Run `/st-generate-tasks 64` on its own only when you want to inspect or hand-tune the blueprint before execution starts.
+
+Your review lands on the plan, before any code exists -- that is where a correction costs a sentence. Each step runs with clean context: the planning agent sees only the work order, and each execution sub-agent receives only its specific task. After execution, an optional automated review gate runs on a discovered second harness, critiques the cumulative diff, and drives bounded remediation if findings exceed configured thresholds.
 
 See the [Workflow Guide](https://strikethroo.canpicasoft.com/workflow.html) for the full step-by-step with advanced patterns. Once a plan exists, visualize its plans, tasks, and dependency graph in [Visualizations](https://strikethroo.canpicasoft.com/visualizations.html).
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 </p>
 
 <p align="center">
-  <strong>Spec-driven development that fits each codebase like a glove.</strong><br>
-  Plain-Markdown hooks teach the agent your conventions, so every plan, task, and run inherits them. No API keys, no extra tools to run.
+  <strong>Spec-driven development optimized for time-to-merge, not time-to-first-draft.</strong><br>
+  You review the plan, where a correction costs a sentence &mdash; not the diff, where it costs a review cycle.
 </p>
 
 <p align="center">
@@ -15,6 +15,7 @@
 </p>
 
 <p align="center">
+  <a href="https://strikethroo.canpicasoft.com/why.html">Why Strikethroo</a> &nbsp;·&nbsp;
   <a href="https://strikethroo.canpicasoft.com/workflow.html">Workflow</a> &nbsp;·&nbsp;
   <a href="https://strikethroo.canpicasoft.com/customization.html">Customization</a> &nbsp;·&nbsp;
   <a href="https://strikethroo.canpicasoft.com/visualizations.html">Visualizations</a> &nbsp;·&nbsp;
@@ -23,49 +24,56 @@
 
 ## Why Strikethroo?
 
+Most spec-driven tools optimize the input: better spec in, better code out, human catches the rest at the end. Strikethroo assumes the agent is an unreliable narrator of its own work -- including a second agent asked to review the first -- and that the scarce resource is your attention, not tokens.
+
 <table>
 <tr>
+<td width="50%" valign="top">
+
+<img src="docs/assets/icons/focus.svg" width="28" height="28" alt="" />
+
+### You review the plan, not the diff
+
+Correcting a plan costs a sentence. Correcting the same misunderstanding in a diff costs a review cycle, a rework cycle, and a re-review. An explicit approval gate puts your careful read where it is worth the most, and one question is asked at a time so it never gets skim-answered.
+
+</td>
+<td width="50%" valign="top">
+
+<img src="docs/assets/icons/shield-check.svg" width="28" height="28" alt="" />
+
+### Guarantees are compiled, not requested
+
+A rule in Markdown is a request; a rule in TypeScript is a guarantee. Hooks and templates are yours to edit. Termination bounds, safety floors, and fail-safe defaults are compiled -- `MAX_REVIEW_ROUNDS` can be tightened by config and raised by nothing.
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+<img src="docs/assets/icons/git-fork.svg" width="28" height="28" alt="" />
+
+### Nobody marks their own homework
+
+The optional review gate runs on a *different* harness than the one that wrote the code -- the current harness is structurally excluded from the candidate set, not merely deprioritized. The reviewer detects and never fixes; remediation is dispatched separately.
+
+</td>
 <td width="50%" valign="top">
 
 <img src="docs/assets/icons/sliders-horizontal.svg" width="28" height="28" alt="" />
 
 ### Bends to your conventions
 
-Plain-Markdown hooks fire at nine points across the workflow; inject your test commands, standards, and domain rules so every plan, task, and run inherits them. No plugins, no code.
+Plain-Markdown hooks fire at eleven points across the workflow; inject your test commands, standards, and domain rules so every plan, task, and run inherits them. No plugins, no code.
 
 </td>
-<td width="50%" valign="top">
-
-<img src="docs/assets/icons/focus.svg" width="28" height="28" alt="" />
-
-### Clean context per agent
-
-Every step runs with a fresh, focused context: the planner sees only your work order, the task generator only the approved plan, each execution sub-agent only its single task. No context bleed, no drift.
-
-</td>
-</tr>
-<tr>
-<td width="50%" valign="top">
-
-<img src="docs/assets/icons/scissors.svg" width="28" height="28" alt="" />
-
-### No API keys
-
-Runs inside the assistant you already use -- Claude Code, Codex, Cursor, OpenCode, or Copilot -- on the subscription you already pay for. Nothing to provision, host, or rotate.
-
-</td>
-<td>
-
-<img src="docs/assets/icons/puzzle.svg" width="28" height="28" alt="" />
-
-### Harness-agnostic skills
-
-The workflow ships as Agent Skills: one `SKILL.md` works on any harness supporting the format. Install once; the right skill auto-loads when you describe what you need.
-
-</td>
-<td width="50%" valign="top"></td>
 </tr>
 </table>
+
+**Speed, measured honestly.** The industry clock starts at the prompt and stops when code appears. The clock that pays your salary stops when the code is **merged** -- and on that clock, generation is a rounding error next to the review rounds a fast-but-wrong draft costs you. Strikethroo is built against the second clock. That is not quality traded for speed; on that clock they are the same number.
+
+Read the full thesis, with the file-by-file claims to verify it yourself: **[Why Strikethroo](https://strikethroo.canpicasoft.com/why.html)**.
+
+<sub>Also true, and less interesting: no API keys (runs on the subscription you already pay for), harness-agnostic Agent Skills (one `SKILL.md` on any harness supporting the format), and clean per-agent context at every step.</sub>
 
 ## Adapts to every codebase
 
@@ -75,7 +83,7 @@ Every codebase has its own conventions, and Strikethroo bends to them instead of
 
 ### <img src="docs/assets/icons/waypoints.svg" width="28" height="28" alt="" /> Hooks
 
-Fire at nine points across the workflow (before planning, after each phase, on errors, and more). Drop in your test commands, coding standards, and domain rules; every plan, task, and execution run inherits them.
+Fire at eleven points across the workflow (before planning, after each phase, on errors, and more). Drop in your test commands, coding standards, and domain rules; every plan, task, and execution run inherits them.
 
 ### <img src="docs/assets/icons/file-text.svg" width="28" height="28" alt="" /> Templates
 
@@ -150,6 +158,7 @@ After blueprint execution, an optional automated code review gate runs when a se
 
 ## Documentation
 
+- [Why Strikethroo](https://strikethroo.canpicasoft.com/why.html) -- The design thesis, the trade-offs stated plainly, and how to verify the claims
 - [Workflow Guide](https://strikethroo.canpicasoft.com/workflow.html) -- Step-by-step workflow with visual guides
 - [Customization Guide](https://strikethroo.canpicasoft.com/customization.html) -- Hooks, templates, project context, and code review configuration
 - [Reference](https://strikethroo.canpicasoft.com/reference.html) -- Glossary and CLI reference

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -76,7 +76,7 @@ The viewer is **read-only except for one permitted mutation: the archive action.
 npx skills add e0ipso/strikethroo
 ```
 
-Installs the Agent Skills that implement the three-step workflow. Skills are fetched from the repository's tagged release via the `.claude-plugin/plugin.json` manifest.
+Installs the Agent Skills that implement the workflow. Skills are fetched from the repository's tagged release via the `.claude-plugin/plugin.json` manifest.
 
 **Pin a specific version:**
 
@@ -105,4 +105,4 @@ Removes the installed Agent Skills. The `.ai/strikethroo/` workspace, plans, and
 | `st-execute-blueprint` | Execution orchestration across all tasks in a plan. |
 | `st-refine-plan` | Plan refinement loop with interactive and autonomous clarification modes. |
 | `st-execute-task` | Single-task execution with dependency and status checks. |
-| `st-full-workflow` | End-to-end orchestration chaining all three steps. |
+| `st-full-workflow` | End-to-end orchestration: plan, tasks, and execution in one pass, with no approval gate. |

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Customization Guide
-nav_order: 3
+nav_order: 4
 description: "Hooks, templates, and workflow customization"
 ---
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: FAQ
-nav_order: 5
+nav_order: 6
 description: "Frequently asked questions about Strikethroo"
 ---
 
@@ -19,7 +19,7 @@ description: "Frequently asked questions about Strikethroo"
 <p>The four steps, automation, and plan mode.</p>
 </a>
 <a class="st-card" href="#code-review">
-<span class="st-card__icon st-card__icon--check-circle" aria-hidden="true"></span>
+<span class="st-card__icon st-card__icon--shield-check" aria-hidden="true"></span>
 <p class="st-card__title">Code Review</p>
 <p>Optional automated review gate, disabling, and limitations.</p>
 </a>
@@ -139,6 +139,24 @@ The `POST_ERROR_DETECTION` hook fires, enabling custom remediation logic. The ta
 Tasks within the same phase have no mutual dependencies and execute concurrently via sub-agents. Phases themselves run in sequence, so a phase starts only after all tasks in the previous phase have completed.
 
 ## Comparison with Other Tools
+
+**How does Strikethroo differ from other spec-driven development frameworks?**
+
+Most spec-driven frameworks optimize the input: write a better specification, get better code, and rely on a human at the end to catch what went wrong. They differ from each other mainly in artifact shape and ceremony. Strikethroo differs on three premises instead:
+
+1. **The agent is an unreliable narrator of its own work.** A subagent reporting success is making a claim, not supplying evidence. A shared verification gate requires identifying the proving command, running it fresh, and reading its exit code before any completion claim. Each skill also ships an anti-rationalization table enumerating the specific excuses a model produces when it is about to skip a discipline.
+2. **A second agent reviewing the first is also unreliable.** So the review gate grades severity and confidence on independent axes with independent floors, treats a missing attribute as below every floor, and explicitly names "manufacturing a finding to justify the round" as the failure it is built to resist.
+3. **The scarce resource is your attention, not tokens.** Your careful read is spent on the plan (where a correction costs a sentence) and on the result, not on the diff (where the same correction costs a review cycle).
+
+The structural consequence is that Strikethroo separates *negotiable* configuration from *compiled* guarantees. Hooks and templates are plain Markdown you own. Termination bounds, safety floors, fail-safe defaults, and the reviewer/implementer separation are compiled into the runtime and cannot be loosened by editing a hook. See [Why Strikethroo](why.html) for the full thesis and the list of claims you can verify in the source.
+
+**Is Strikethroo slower because of all the gates?**
+
+Not on the clock that matters. Measured from prompt to first draft, a tool with no gates is faster. Measured from picking up the work to merging it, the cost sits in the review rounds a fast-but-wrong draft generates -- the dropped requirement found in review, the fix that breaks something adjacent, the re-read of a diff you have already read twice. Strikethroo is designed against that second clock, and it runs tasks in parallel within each phase rather than serially.
+
+**Does the automated review gate replace human code review?**
+
+No. It is a filter that runs *before* you look, not a substitute for looking. Its mandate is deliberately narrow -- requirement conformance and demonstrable defects only -- and it is explicitly forbidden from raising design or abstraction opinions, because design judgment is what your read is being preserved for. A green gate is not a correctness guarantee; it reduces exposure to the same class of error a human PR approval reduces, and leaves the same class behind.
 
 **How does Strikethroo differ from API-based tools like Plandex or Claude Task Master?**
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,7 +16,7 @@ description: "Frequently asked questions about Strikethroo"
 <a class="st-card" href="#workflow">
 <span class="st-card__icon st-card__icon--workflow" aria-hidden="true"></span>
 <p class="st-card__title">Workflow</p>
-<p>The four steps, automation, and plan mode.</p>
+<p>The two commands, automation, and plan mode.</p>
 </a>
 <a class="st-card" href="#code-review">
 <span class="st-card__icon st-card__icon--shield-check" aria-hidden="true"></span>
@@ -60,21 +60,24 @@ Yes. Initialize with multiple harnesses (`--harnesses claude,gemini,codex`). All
 
 ## Workflow
 
-**What is the three-step workflow?**
+**What is the workflow?**
 
-1. **Planning**: The `st-create-plan` skill refines your work order into a comprehensive plan.
-2. **Task generation**: The `st-generate-tasks` skill decomposes the plan into an execution blueprint -- atomic tasks organized into dependency-mapped phases.
-3. **Execution**: The `st-execute-blueprint` skill implements each task using sub-agents with focused context.
+Two commands:
 
-Each step produces files in `.ai/strikethroo/plans/` for human review before the next step begins.
+1. **Planning**: `/st-create-plan <your request>` refines your work order into a comprehensive plan. You read it and approve it.
+2. **Execution**: `/st-execute-blueprint <plan-id>` decomposes the plan into an execution blueprint -- atomic tasks in dependency-mapped phases -- and then implements each task using sub-agents with focused context.
 
-**Do I have to use all three steps?**
+Everything lands in `.ai/strikethroo/plans/`, so you can inspect any of it at any point.
 
-No. You can use only plan creation without task generation, generate tasks without executing, execute specific tasks manually, or skip steps that do not apply. The three-step workflow is recommended but not mandatory.
+**Why is there no separate task-generation step?**
+
+There is one -- `st-generate-tasks` -- but you rarely need to run it. `st-execute-blueprint` generates the tasks and blueprint itself when the plan does not have them yet, so the normal path is plan, review, execute.
+
+Running it separately is worth it when you want to see or hand-tune the decomposition before execution starts: an unusually large plan, or one whose phase ordering you want to check. It is a detour, not a step. Your careful reading is better spent on the plan, where a correction costs a sentence.
 
 **What if I want fully automated execution?**
 
-The `st-full-workflow` skill chains all three steps in a single invocation. It is best suited for well-defined features with clear scope. For complex features that need review between steps, use the manual step-by-step workflow.
+The `st-full-workflow` skill runs planning and execution in a single invocation, with no stop for your approval of the plan. It is best suited for well-defined features with clear scope. For anything where the plan is worth a read first, use the two-command workflow.
 
 **How does Strikethroo relate to plan mode?**
 
@@ -118,7 +121,7 @@ The conformance-only scope emphasizes traces back to explicit plan requirements.
 
 **Can I customize the workflow?**
 
-Yes. Nine lifecycle hooks, four templates, and project-context files are all editable Markdown. See the [Customization Guide](customization.html) for examples.
+Yes. Eleven lifecycle hooks, four templates, and project-context files are all editable Markdown. See the [Customization Guide](customization.html) for examples.
 
 **What file formats does it use?**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,25 +84,24 @@ flowchart LR
     A[Work Order] --> B[Plan]
     B --> C{Review}
     C -->|Edit| B
-    C -->|Approve| D[Tasks]
-    D --> E{Verify}
-    E --> G[Execute]
+    C -->|Approve| G["Execute<br/>(generates tasks)"]
     G --> H["Code Review<br/>(optional)"]
     H -->|Fix| G
     H -->|Pass| J[Done]
 ```
 
-Four steps, three delivered as Agent Skills that load when you describe what you need:
+**Two commands.** Read the plan, approve it, run it:
 
-| Step        | Skill                           | Output                                            |
-|-------------|---------------------------------|---------------------------------------------------|
-| **Plan**    | `/st-create-plan <your prompt>` | `.ai/strikethroo/plans/64--auth/plan-64--auth.md` |
-| **Tasks**   | `/st-generate-tasks 64`         | `.ai/strikethroo/plans/64--auth/tasks/*.md`       |
-| **Execute** | `/st-execute-blueprint 64`      | Working code, one commit per phase                |
-| **Review**  | Automatic (optional)            | Findings validated against schema; bounded fixes  |
+| Step        | Command                         | Output                                                  |
+|-------------|---------------------------------|---------------------------------------------------------|
+| **Plan**    | `/st-create-plan <your prompt>` | `.ai/strikethroo/plans/64--auth/plan-64--auth.md`       |
+| **Execute** | `/st-execute-blueprint 64`      | Task blueprint, then working code, one commit per phase |
+| **Review**  | Automatic (optional)            | Findings validated against schema; bounded fixes        |
+
+`st-execute-blueprint` decomposes the plan into atomic tasks and builds the dependency-mapped blueprint itself when one does not exist yet. Run `/st-generate-tasks 64` on its own only when you want to inspect or hand-tune the blueprint before execution starts.
 
 {% capture context_note %}
-Human review gates between steps catch scope creep before any code is written. Each step runs with clean context &mdash; the planning agent sees only the work order, the task agent sees only the approved plan, and each execution sub-agent receives only its specific task. After execution, an optional automated review gate runs on a discovered second harness, critiques the cumulative diff, and drives bounded remediation if findings exceed configured thresholds.
+Your review lands on the plan, before any code exists &mdash; that is where a correction costs a sentence. Each step runs with clean context: the planning agent sees only the work order, and each execution sub-agent receives only its specific task. After execution, an optional automated review gate runs on a discovered second harness, critiques the cumulative diff, and drives bounded remediation if findings exceed configured thresholds.
 {% endcapture %}
 {% include callout.html variant="note" title="WHY THE GATES MATTER" content=context_note %}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,32 +11,40 @@ description: "Structured AI task management with plain text files and Agent Skil
 
 # Strikethroo
 
-Strikethroo is spec-driven development that fits each codebase like a glove. Plain-Markdown hooks teach the agent your conventions -- test commands, coding standards, domain rules -- so every plan, task, and run inherits them. No API keys, no extra tools: it works inside the AI subscription you already pay for, on any harness that supports the Agent Skills format.
+Strikethroo is spec-driven development optimized for **time-to-merge, not time-to-first-draft**. You review the plan, where a correction costs a sentence -- not the diff, where the same correction costs a review cycle. It works inside the AI subscription you already pay for, on any harness that supports the Agent Skills format.
 
 ## Why Strikethroo?
 
+Most spec-driven tools optimize the input: better spec in, better code out, human catches the rest at the end. Strikethroo assumes the agent is an unreliable narrator of its own work -- including a second agent asked to review the first -- and that the scarce resource is your attention, not tokens.
+
 <div class="st-cards" markdown="0">
+<div class="st-card">
+<span class="st-card__icon st-card__icon--focus" aria-hidden="true"></span>
+<p class="st-card__title">You review the plan, not the diff</p>
+<p>Correcting a plan costs a sentence. Correcting the same misunderstanding in a diff costs a review cycle, a rework cycle, and a re-review. An explicit approval gate puts your careful read where it is worth the most, and one question is asked at a time so it never gets skim-answered.</p>
+</div>
+<div class="st-card">
+<span class="st-card__icon st-card__icon--shield-check" aria-hidden="true"></span>
+<p class="st-card__title">Guarantees are compiled, not requested</p>
+<p>A rule in Markdown is a request; a rule in TypeScript is a guarantee. Hooks and templates are yours to edit. Termination bounds, safety floors, and fail-safe defaults are compiled &mdash; <code>MAX_REVIEW_ROUNDS</code> can be tightened by config and raised by nothing.</p>
+</div>
+<div class="st-card">
+<span class="st-card__icon st-card__icon--git-fork" aria-hidden="true"></span>
+<p class="st-card__title">Nobody marks their own homework</p>
+<p>The optional review gate runs on a <em>different</em> harness than the one that wrote the code &mdash; the current harness is structurally excluded from the candidate set, not merely deprioritized. The reviewer detects and never fixes; remediation is dispatched separately.</p>
+</div>
 <div class="st-card">
 <span class="st-card__icon st-card__icon--sliders-horizontal" aria-hidden="true"></span>
 <p class="st-card__title">Bends to your conventions</p>
-<p>Plain-Markdown hooks fire at nine points across the workflow &mdash; inject your test commands, standards, and domain rules so every plan, task, and run inherits them. No plugins, no code.</p>
-</div>
-<div class="st-card">
-<span class="st-card__icon st-card__icon--focus" aria-hidden="true"></span>
-<p class="st-card__title">Clean context per agent</p>
-<p>Every step runs with a fresh, focused context. The planner sees only your work order, the task generator only the approved plan, and each execution sub-agent only its single task. No context bleed, no drift.</p>
-</div>
-<div class="st-card">
-<span class="st-card__icon st-card__icon--key-round" aria-hidden="true"></span>
-<p class="st-card__title">No API keys</p>
-<p>Runs entirely inside the assistant you already use &mdash; Claude Code, Codex, Cursor, OpenCode, or Copilot &mdash; on the subscription you already pay for. Nothing to provision, host, or rotate.</p>
-</div>
-<div class="st-card">
-<span class="st-card__icon st-card__icon--blocks" aria-hidden="true"></span>
-<p class="st-card__title">Harness-agnostic skills</p>
-<p>The workflow ships as Agent Skills: one <code>SKILL.md</code> works on any harness supporting the format. Install once, and the right skill auto-loads when you describe what you need.</p>
+<p>Plain-Markdown hooks fire at eleven points across the workflow &mdash; inject your test commands, standards, and domain rules so every plan, task, and run inherits them. No plugins, no code.</p>
 </div>
 </div>
+
+**Speed, measured honestly.** The industry clock starts at the prompt and stops when code appears. The clock that pays your salary stops when the code is **merged** -- and on that clock, generation is a rounding error next to the review rounds a fast-but-wrong draft costs you. Strikethroo is built against the second clock. That is not quality traded for speed; on that clock they are the same number.
+
+Read the full thesis, with the file-by-file claims to verify it yourself: **[Why Strikethroo](why.html)**.
+
+{% include callout.html variant="note" content="Also true, and less interesting: no API keys (runs on the subscription you already pay for), harness-agnostic Agent Skills (one `SKILL.md` on any harness supporting the format), and clean per-agent context at every step." %}
 
 ## Adapts to every codebase
 
@@ -44,7 +52,7 @@ Every codebase has its own conventions, and Strikethroo bends to them instead of
 
 ![Strikethroo's customizable spec-driven workflow, showing where the hooks fire: PRE_PLAN, POST_PLAN, POST_TASK_GENERATION_ALL, PRE_TASK_ASSIGNMENT, and POST_EXECUTION]({{ '/assets/strikethroo-customization.png' | relative_url }})
 
-- **Hooks** fire at nine points across the workflow (before planning, after each phase, on errors, and more). Drop in your test commands, coding standards, and domain rules; every plan, task, and execution run inherits them.
+- **Hooks** fire at eleven points across the workflow (before planning, after each phase, on errors, and more). Drop in your test commands, coding standards, and domain rules; every plan, task, and execution run inherits them.
 - **Templates** define the shape of plans and tasks -- add your own sections and checklists.
 - **Project context** is one file of domain knowledge every step reads.
 
@@ -79,21 +87,22 @@ flowchart LR
     C -->|Approve| D[Tasks]
     D --> E{Verify}
     E --> G[Execute]
-    G --> H{Review}
-    H -->|Edit| G
-    H -->|Approve| J[Done]
+    G --> H["Code Review<br/>(optional)"]
+    H -->|Fix| G
+    H -->|Pass| J[Done]
 ```
 
-Three steps, each delivered as an Agent Skill that loads when you describe what you need:
+Four steps, three delivered as Agent Skills that load when you describe what you need:
 
 | Step        | Skill                           | Output                                            |
 |-------------|---------------------------------|---------------------------------------------------|
 | **Plan**    | `/st-create-plan <your prompt>` | `.ai/strikethroo/plans/64--auth/plan-64--auth.md` |
 | **Tasks**   | `/st-generate-tasks 64`         | `.ai/strikethroo/plans/64--auth/tasks/*.md`       |
 | **Execute** | `/st-execute-blueprint 64`      | Working code, one commit per phase                |
+| **Review**  | Automatic (optional)            | Findings validated against schema; bounded fixes  |
 
 {% capture context_note %}
-Human review gates between steps catch scope creep before any code is written. Each step runs with clean context &mdash; the planning agent sees only the work order, the task agent sees only the approved plan, and each execution sub-agent receives only its specific task.
+Human review gates between steps catch scope creep before any code is written. Each step runs with clean context &mdash; the planning agent sees only the work order, the task agent sees only the approved plan, and each execution sub-agent receives only its specific task. After execution, an optional automated review gate runs on a discovered second harness, critiques the cumulative diff, and drives bounded remediation if findings exceed configured thresholds.
 {% endcapture %}
 {% include callout.html variant="note" title="WHY THE GATES MATTER" content=context_note %}
 
@@ -116,6 +125,11 @@ This will open a web page that will help you navigate your plans and their tasks
 ## Documentation
 
 <div class="st-cards" markdown="0">
+<a class="st-card" href="{{ '/why.html' | relative_url }}">
+<span class="st-card__icon st-card__icon--shield-check" aria-hidden="true"></span>
+<p class="st-card__title">Why Strikethroo</p>
+<p>The design thesis, the trade-offs stated plainly, and how to verify the claims.</p>
+</a>
 <a class="st-card" href="{{ '/workflow.html' | relative_url }}">
 <span class="st-card__icon st-card__icon--workflow" aria-hidden="true"></span>
 <p class="st-card__title">Workflow Guide</p>

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Migrating from AI Task Manager
-nav_order: 7
+nav_order: 8
 description: "Upgrade from AI Task Manager to Strikethroo"
 ---
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Reference
-nav_order: 4
+nav_order: 5
 has_children: true
 description: "Glossary and CLI command reference"
 ---

--- a/docs/visualizations.md
+++ b/docs/visualizations.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Visualizations
-nav_order: 6
+nav_order: 7
 description: "See your plans, tasks, dependency graph, and archive in a live, read-only web app"
 ---
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -7,231 +7,113 @@ description: "The design thesis: where human attention gets spent, and which gua
 
 # Why Strikethroo
 
-Most spec-driven development frameworks optimize the same thing: the input. Write
-a better specification, get better code. They differ in artifact shape and
-ceremony — a constitution, a set of personas, WHEN/THEN scenarios — but they share
-one assumption: **that an agent handed a good spec will faithfully implement it,
-and that a human at the end will catch it when it doesn't.**
+Most spec-driven frameworks optimize the input: better spec in, better code out,
+human catches the rest at the end. Strikethroo starts from three different
+premises.
 
-Strikethroo starts somewhere else. It assumes the agent is an unreliable narrator
-of its own work, that a second agent asked to check the first is *also* an
-unreliable narrator, and that the scarce resource in the whole loop is not tokens
-but **your attention**. Nearly every design decision below follows from those
-three premises.
+1. **The agent is an unreliable narrator of its own work.** A success report is a
+   claim, not evidence.
+2. **A second agent reviewing the first is also unreliable.** It will overstate
+   confidence and manufacture findings to justify its round.
+3. **The scarce resource is your attention, not tokens.**
 
----
+Everything below follows from those.
 
 ## Speed is measured at the wrong checkpoint
 
-The industry clock starts when you type the prompt and stops when code appears.
-By that clock, a tool that generates a thousand lines in ninety seconds is fast.
+The usual clock starts at the prompt and stops when code appears. The clock that
+pays your salary stops when the code is **merged** — and on that clock,
+generation is a rounding error next to the review rounds a fast-but-wrong draft
+costs you.
 
-That is not the clock that pays your salary. The clock that matters starts when
-you pick up the work and stops **when the code is merged**. On that clock,
-generation is a rounding error. The cost is in what comes after:
+Strikethroo is built against the second clock. That is not quality traded for
+speed. On that clock they are the same number.
 
-- The review round where someone finds that a requirement was quietly dropped.
-- The second round, after the fix, because the fix broke something adjacent.
-- The re-read of a diff you have already read twice, because you no longer trust
-  your own earlier pass.
-- The judgment call you cannot make from the diff alone, so you go re-derive what
-  the feature was supposed to do.
+## Attention is the budget
 
-None of that appears in a demo. All of it appears in your week. A framework that
-generates quickly and lands slowly has not made you faster — it has moved the
-cost somewhere nobody is counting.
-
-Strikethroo is built against the time-to-merge clock. That is not a trade of
-speed for quality. On that clock, they are the same number.
-
----
-
-## Your attention is the budget
-
-If the bottleneck is human review, the design question is not *how do we reduce
-review* — it is **where in the process is a correction cheapest?**
-
-Correcting a plan costs one sentence. Correcting the same misunderstanding in a
-diff costs a review cycle, a rework cycle, and a re-review. The ratio is not
-close. So Strikethroo deliberately rations attention rather than maximizing it:
+A correction costs one sentence in the plan and a full review cycle in the diff.
+So attention is rationed, not maximized:
 
 | Stage | Your involvement | Why |
 | --- | --- | --- |
-| **Plan** | A careful read, with an explicit approval gate | Corrections are one sentence here. This is where your judgment is worth the most. |
-| **Blueprint** | A quick verification pass | Structure, not substance. A skim is the correct level of care. |
-| **Execution** | None | Every task carries concrete, runnable acceptance criteria. There is nothing here your attention improves. |
-| **Result** | A careful read | Does this do what you asked? The one question a machine cannot answer for you. |
+| **Plan** | Careful read, explicit approval gate | Corrections cost a sentence here |
+| **Blueprint** | Quick verification pass | Structure, not substance |
+| **Execution** | None | Tasks carry runnable acceptance criteria |
+| **Result** | Careful read | "Does this do what I asked?" — the one question a machine can't answer |
 
-The clarification gate exists to make the first row work. It asks **one question
-at a time**, offers multiple choice with a recommended default where it can, and
-requires explicit confirmation of scope before it writes anything. Batched
-questionnaires get skim-answered; that is a known failure mode, and it is
-designed against directly. If you decline to answer a blocking question, planning
-**stops** rather than proceeding on an invented answer.
+The clarification gate makes the first row work: **one question at a time**,
+multiple-choice where possible, explicit scope confirmation before anything is
+written. Decline a blocking question and planning *stops* rather than inventing
+an answer.
 
-This is why the automated review gate is not a replacement for you. It is a
-**filter that runs before you look**, so that your read lands on "this doesn't do
-what I asked" instead of "you forgot the null check." The gate is scoped to
-conformance and demonstrable defects and is explicitly forbidden from raising
-design opinions — because design judgment is precisely the thing your read is
-being preserved for. It is built to *not* do your job.
-
----
+The automated review gate is a **filter that runs before you look**, not a
+replacement for looking. It is scoped to requirement conformance and demonstrable
+defects, and explicitly forbidden from raising design opinions — because design
+judgment is what your read is being preserved for.
 
 ## Guarantees are compiled, not requested
 
-Here is the distinction that most cleanly separates Strikethroo from frameworks
-whose enforcement lives entirely in prompt text: **a rule written in Markdown is a
-request. A rule written in TypeScript is a guarantee.**
+**A rule in Markdown is a request. A rule in TypeScript is a guarantee.**
 
-Strikethroo draws that line deliberately and in the same place every time.
+- **Negotiable** — hooks at eleven workflow points, plan/task templates, project
+  context. Plain Markdown. Yours.
+- **Compiled** — termination bounds, severity/confidence floors, fail-safe
+  defaults, reviewer/implementer separation. Not read from a hook, so not
+  loosenable by editing one.
 
-**Negotiable — plain Markdown you own and edit.** Hooks at eleven points in the
-workflow, plan and task templates, and one project-context file. This is the
-adaptation surface. Change it freely; it is yours.
+Concretely: `MAX_REVIEW_ROUNDS` is a constant. A hook may state a round budget and
+it is honored — after clamping. **You can tighten the bound; nothing can raise
+it.** A finding that *omits* `severity` or `confidence` falls below every floor,
+so omission is never a route to auto-applying a change.
 
-**Non-negotiable — compiled into the runtime.** Termination bounds, safety floors,
-fail-safe defaults, and the separation between reviewer and implementer. You
-cannot loosen these by editing a hook, because they are not read from one.
-
-Concretely, in `src/skill-scripts/shared/review-findings.ts`:
-
-- `MAX_REVIEW_ROUNDS` is a compiled constant. The review hook may state a round
-  budget, and it is honored — but it is clamped to the ceiling first. **A user
-  editing the hook can tighten the bound. Nothing can raise it.** The parser is
-  documented as "forgiving in exactly one direction."
-- A finding that **omits** `severity` or `confidence` is treated as falling below
-  *every* floor. Omission is never a route to getting a change auto-applied. The
-  default is fail-safe, and there is exactly one place in the code where that
-  default lives.
-- Severity and confidence are independent axes with separate floors, because they
-  answer different questions — *how bad if real* versus *how sure it is real* —
-  and an automated consumer that conflates them will apply speculative changes to
-  working code.
-
-This is the property to check if you are evaluating Strikethroo against anything
-else: **find the guarantee, then find where it is enforced.** If the only thing
-standing between you and an unbounded loop is a sentence in a prompt file asking
+The question to ask of any framework: **find the guarantee, then find where it is
+enforced.** If the only thing between you and an unbounded loop is a prompt asking
 the model to stop, that is not a bound.
-
----
 
 ## Nobody marks their own homework
 
-When the optional review gate runs, the reviewer runs on a **different harness**
-than the one that wrote the code. This is not a preference or a default — the
-current harness is structurally removed from the candidate set in
-`src/skill-scripts/shared/harness-discovery.ts`, with the reason stated inline:
-*a reviewer on the same harness as the implementer defeats the point of the gate.*
+The reviewer runs on a **different harness** than the one that wrote the code —
+the current harness is structurally removed from the candidate set, not merely
+deprioritized. The reviewer **detects and never fixes**; remediation is dispatched
+separately.
 
-The same separation holds at the role level. The reviewer **detects and never
-fixes**. It may not edit files, run formatters, or commit. Remediation is
-dispatched separately, and the implementer receives the finding without the
-reviewer's reasoning about it.
+This also reframes execution routing. Sending tasks to different models looks like
+cost optimization. Here it is the review gate's idea in another hat: **models fail
+differently, so a second model is an independent sample, not a cheaper one.**
 
-This also reframes execution routing. Sending tasks to different models looks
-like a cost optimization, and elsewhere it is marketed as one. In Strikethroo it
-is the same idea as the review gate wearing a different hat: **models fail
-differently, so a second model is an independent sample, not merely a cheaper
-one.** Heterogeneity is a correctness mechanism here.
+Two more places the distrust is structural rather than requested:
 
----
+- **An empty diff is reported, never certified.** A reviewer handed nothing
+  returns no findings — indistinguishable from a clean review. Empty scope
+  short-circuits to a recorded skip before any reviewer is dispatched.
+- **A skip is not a pass.** No second harness, no validator, no base commit → the
+  gate records that it did not run, and why. It never degrades into silence that
+  reads as success.
 
-## The agent is not trusted, including about itself
+## The costs
 
-Two shared disciplines are loaded at runtime by the skills that need them. They
-are short on purpose.
-
-**The verification gate.** Before any claim that something is complete, passing,
-or working: identify the command that proves it, run it *now*, read the full
-output and exit code, then state the result. Its operative line, which the phase
-loop restates: *"Do not accept a subagent's report of success as proof."* A report
-is a claim. The words *should*, *probably*, *seems to*, and a premature *Done!*
-are named as red flags meaning the gate has not been run.
-
-**Anti-rationalization.** Every skill that enforces a discipline ships a table of
-**the specific excuses a model generates when it is about to skip that
-discipline**, each paired with a binding rule. Not general advice — enumerated
-failure modes. From the planner:
-
-> *"I can reasonably assume the answer."* → An assumption is not an answer. Ask the
-> question; never invent answers.
-
-And the reviewer's table points entirely at the reviewer:
-
-> *"I have found nothing above the floor; I should look harder so this round
-> produces something."* → A clean diff is a valid result. Manufacturing a finding
-> to justify the round **is** the defect this gate exists to prevent.
-
-> *"This is only minor, but it is real, so I will call it major so it gets
-> fixed."* → Severity is impact if real, never a lever for clearing the floor.
-
-There is no "unless it matters" exception, and that is stated explicitly, because
-a discipline with a judgment-call escape hatch is a discipline the model will
-negotiate its way out of under pressure.
-
-Two more places the same distrust shows up in code:
-
-- **An empty diff is reported, never certified.** A reviewer handed nothing to
-  read returns no findings — which is indistinguishable from a clean review. So
-  an empty scope short-circuits to a recorded skip *before* a reviewer is
-  dispatched. Without that branch, the one observable symptom of a collapsed
-  review scope would be a pass.
-- **A skip is not a pass.** When the gate cannot run — no second harness, no
-  schema validator, no recorded base commit — it records that it did not run and
-  says why. It never degrades into silence that reads as success.
-
----
-
-## The costs, stated plainly
-
-A framework that only lists its advantages is asking you to trust it. These are
-in the source with their reasoning attached.
-
-- **The reviewer will miss "this works, matches the plan, and the abstraction is
-  wrong."** That is a real category, and one a second model is unusually good at
-  spotting. It is excluded deliberately: the gate is unattended and auto-applies
-  fixes, so its false-positive rate matters more than its recall. The trade is
-  documented in the reviewer prompt as an accepted cost, not an oversight.
-- **A fix that cannot be expressed as a local text replacement is recorded and
-  not applied.** This is what structurally prevents an unattended reviewer from
-  landing broad speculative refactors — a constraint on shape rather than a
-  request for restraint.
-- **A green gate is not a correctness guarantee.** It reduces exposure to the same
-  class of error a human PR approval reduces, and leaves the same class behind.
-- **Blast-radius analysis is a partial mitigation**, not a complete one. The
-  reviewer reads callsites of changed symbols outside the diff; it does not read
-  your whole codebase.
-
----
+- **The reviewer will miss "works, matches the plan, wrong abstraction."** Real
+  category, deliberately excluded: the gate is unattended and auto-applies fixes,
+  so false-positive rate matters more than recall.
+- **A fix that isn't a local text replacement is recorded, not applied.** This is
+  what structurally prevents speculative refactors landing unattended.
+- **A green gate is not a correctness guarantee.** It reduces the same class of
+  error a human PR approval reduces, and leaves the same class behind.
+- **Blast-radius analysis is partial.** Callsites of changed symbols, not your
+  whole codebase.
 
 ## Check the claims
 
-Every claim above about Strikethroo is verifiable in this repository. That is
-intentional — you should not have to take positioning on faith.
-
-| Claim | Where to check |
+| Claim | Where |
 | --- | --- |
-| Round bound is compiled and cannot be raised by config | `MAX_REVIEW_ROUNDS` in `src/skill-scripts/shared/review-findings.ts` |
-| Missing attributes fail safe | `partitionFindings` in the same file |
-| Reviewer cannot be the implementer's harness | `discoverHarnesses` in `src/skill-scripts/shared/harness-discovery.ts` |
-| Subagent reports are not accepted as proof | `config/shared/verification-gate.md`, and the phase loop in `src/skill-prompts/sections/phase-execution-loop.md` |
-| Excuses are enumerated per skill | the rationalization tables in `src/skill-prompts/st-*.md` |
-| Reviewer detects and never fixes | the Role section of `src/skill-prompts/st-code-review.md` |
-| Empty scope skips instead of passing | the `empty-diff` branch in `src/skill-scripts/code-review.ts` |
-| Human approval gates the plan | `config/shared/clarification-gate.md` and [Workflow](workflow.html) |
+| Round bound compiled, not raisable by config | `MAX_REVIEW_ROUNDS` in `src/skill-scripts/shared/review-findings.ts` |
+| Missing attributes fail safe | `partitionFindings`, same file |
+| Reviewer can't be the implementer's harness | `discoverHarnesses` in `src/skill-scripts/shared/harness-discovery.ts` |
+| Subagent reports aren't proof | `config/shared/verification-gate.md` |
+| Excuses enumerated per skill | rationalization tables in `src/skill-prompts/st-*.md` |
+| Reviewer detects, never fixes | Role section, `src/skill-prompts/st-code-review.md` |
+| Empty scope skips instead of passing | `empty-diff` branch in `src/skill-scripts/code-review.ts` |
+| Human approval gates the plan | `config/shared/clarification-gate.md`, [Workflow](workflow.html) |
 
----
-
-## In one paragraph
-
-Strikethroo spends your attention at the plan, where a correction costs a
-sentence, and withholds it from the diff, where the same correction costs a review
-cycle. It treats the model — including a model reviewing another model — as a
-component with known failure modes rather than a colleague with good intentions,
-and it enforces the bounds that matter in compiled code rather than asking for
-them in prose. The result is not a trade of speed for quality. On a clock that
-starts at the idea and stops at the merge, it is the same thing.
-
-Next: the [Workflow Guide](workflow.html) for the step-by-step, or
-[Customization](customization.html) for the surfaces you own.
+Next: the [Workflow Guide](workflow.html), or [Customization](customization.html)
+for the surfaces you own.

--- a/docs/why.md
+++ b/docs/why.md
@@ -29,7 +29,7 @@ So attention is rationed, not maximized:
 | Stage | Your involvement | Why |
 | --- | --- | --- |
 | **Plan** | Careful read, explicit approval gate | Corrections cost a sentence here. One question asked at a time, so it never gets skim-answered |
-| **Blueprint** | Quick verification pass | Structure, not substance |
+| **Blueprint** | None | Generated inside execution. It is machinery, not a decision — inspect it separately only to hand-tune |
 | **Execution** | None | Tasks carry runnable acceptance criteria |
 | **Result** | Careful read | "Does this do what I asked?" — the one question a machine can't answer |
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -1,0 +1,237 @@
+---
+layout: default
+title: Why Strikethroo
+nav_order: 2
+description: "The design thesis: where human attention gets spent, and which guarantees are compiled rather than requested"
+---
+
+# Why Strikethroo
+
+Most spec-driven development frameworks optimize the same thing: the input. Write
+a better specification, get better code. They differ in artifact shape and
+ceremony — a constitution, a set of personas, WHEN/THEN scenarios — but they share
+one assumption: **that an agent handed a good spec will faithfully implement it,
+and that a human at the end will catch it when it doesn't.**
+
+Strikethroo starts somewhere else. It assumes the agent is an unreliable narrator
+of its own work, that a second agent asked to check the first is *also* an
+unreliable narrator, and that the scarce resource in the whole loop is not tokens
+but **your attention**. Nearly every design decision below follows from those
+three premises.
+
+---
+
+## Speed is measured at the wrong checkpoint
+
+The industry clock starts when you type the prompt and stops when code appears.
+By that clock, a tool that generates a thousand lines in ninety seconds is fast.
+
+That is not the clock that pays your salary. The clock that matters starts when
+you pick up the work and stops **when the code is merged**. On that clock,
+generation is a rounding error. The cost is in what comes after:
+
+- The review round where someone finds that a requirement was quietly dropped.
+- The second round, after the fix, because the fix broke something adjacent.
+- The re-read of a diff you have already read twice, because you no longer trust
+  your own earlier pass.
+- The judgment call you cannot make from the diff alone, so you go re-derive what
+  the feature was supposed to do.
+
+None of that appears in a demo. All of it appears in your week. A framework that
+generates quickly and lands slowly has not made you faster — it has moved the
+cost somewhere nobody is counting.
+
+Strikethroo is built against the time-to-merge clock. That is not a trade of
+speed for quality. On that clock, they are the same number.
+
+---
+
+## Your attention is the budget
+
+If the bottleneck is human review, the design question is not *how do we reduce
+review* — it is **where in the process is a correction cheapest?**
+
+Correcting a plan costs one sentence. Correcting the same misunderstanding in a
+diff costs a review cycle, a rework cycle, and a re-review. The ratio is not
+close. So Strikethroo deliberately rations attention rather than maximizing it:
+
+| Stage | Your involvement | Why |
+| --- | --- | --- |
+| **Plan** | A careful read, with an explicit approval gate | Corrections are one sentence here. This is where your judgment is worth the most. |
+| **Blueprint** | A quick verification pass | Structure, not substance. A skim is the correct level of care. |
+| **Execution** | None | Every task carries concrete, runnable acceptance criteria. There is nothing here your attention improves. |
+| **Result** | A careful read | Does this do what you asked? The one question a machine cannot answer for you. |
+
+The clarification gate exists to make the first row work. It asks **one question
+at a time**, offers multiple choice with a recommended default where it can, and
+requires explicit confirmation of scope before it writes anything. Batched
+questionnaires get skim-answered; that is a known failure mode, and it is
+designed against directly. If you decline to answer a blocking question, planning
+**stops** rather than proceeding on an invented answer.
+
+This is why the automated review gate is not a replacement for you. It is a
+**filter that runs before you look**, so that your read lands on "this doesn't do
+what I asked" instead of "you forgot the null check." The gate is scoped to
+conformance and demonstrable defects and is explicitly forbidden from raising
+design opinions — because design judgment is precisely the thing your read is
+being preserved for. It is built to *not* do your job.
+
+---
+
+## Guarantees are compiled, not requested
+
+Here is the distinction that most cleanly separates Strikethroo from frameworks
+whose enforcement lives entirely in prompt text: **a rule written in Markdown is a
+request. A rule written in TypeScript is a guarantee.**
+
+Strikethroo draws that line deliberately and in the same place every time.
+
+**Negotiable — plain Markdown you own and edit.** Hooks at eleven points in the
+workflow, plan and task templates, and one project-context file. This is the
+adaptation surface. Change it freely; it is yours.
+
+**Non-negotiable — compiled into the runtime.** Termination bounds, safety floors,
+fail-safe defaults, and the separation between reviewer and implementer. You
+cannot loosen these by editing a hook, because they are not read from one.
+
+Concretely, in `src/skill-scripts/shared/review-findings.ts`:
+
+- `MAX_REVIEW_ROUNDS` is a compiled constant. The review hook may state a round
+  budget, and it is honored — but it is clamped to the ceiling first. **A user
+  editing the hook can tighten the bound. Nothing can raise it.** The parser is
+  documented as "forgiving in exactly one direction."
+- A finding that **omits** `severity` or `confidence` is treated as falling below
+  *every* floor. Omission is never a route to getting a change auto-applied. The
+  default is fail-safe, and there is exactly one place in the code where that
+  default lives.
+- Severity and confidence are independent axes with separate floors, because they
+  answer different questions — *how bad if real* versus *how sure it is real* —
+  and an automated consumer that conflates them will apply speculative changes to
+  working code.
+
+This is the property to check if you are evaluating Strikethroo against anything
+else: **find the guarantee, then find where it is enforced.** If the only thing
+standing between you and an unbounded loop is a sentence in a prompt file asking
+the model to stop, that is not a bound.
+
+---
+
+## Nobody marks their own homework
+
+When the optional review gate runs, the reviewer runs on a **different harness**
+than the one that wrote the code. This is not a preference or a default — the
+current harness is structurally removed from the candidate set in
+`src/skill-scripts/shared/harness-discovery.ts`, with the reason stated inline:
+*a reviewer on the same harness as the implementer defeats the point of the gate.*
+
+The same separation holds at the role level. The reviewer **detects and never
+fixes**. It may not edit files, run formatters, or commit. Remediation is
+dispatched separately, and the implementer receives the finding without the
+reviewer's reasoning about it.
+
+This also reframes execution routing. Sending tasks to different models looks
+like a cost optimization, and elsewhere it is marketed as one. In Strikethroo it
+is the same idea as the review gate wearing a different hat: **models fail
+differently, so a second model is an independent sample, not merely a cheaper
+one.** Heterogeneity is a correctness mechanism here.
+
+---
+
+## The agent is not trusted, including about itself
+
+Two shared disciplines are loaded at runtime by the skills that need them. They
+are short on purpose.
+
+**The verification gate.** Before any claim that something is complete, passing,
+or working: identify the command that proves it, run it *now*, read the full
+output and exit code, then state the result. Its operative line, which the phase
+loop restates: *"Do not accept a subagent's report of success as proof."* A report
+is a claim. The words *should*, *probably*, *seems to*, and a premature *Done!*
+are named as red flags meaning the gate has not been run.
+
+**Anti-rationalization.** Every skill that enforces a discipline ships a table of
+**the specific excuses a model generates when it is about to skip that
+discipline**, each paired with a binding rule. Not general advice — enumerated
+failure modes. From the planner:
+
+> *"I can reasonably assume the answer."* → An assumption is not an answer. Ask the
+> question; never invent answers.
+
+And the reviewer's table points entirely at the reviewer:
+
+> *"I have found nothing above the floor; I should look harder so this round
+> produces something."* → A clean diff is a valid result. Manufacturing a finding
+> to justify the round **is** the defect this gate exists to prevent.
+
+> *"This is only minor, but it is real, so I will call it major so it gets
+> fixed."* → Severity is impact if real, never a lever for clearing the floor.
+
+There is no "unless it matters" exception, and that is stated explicitly, because
+a discipline with a judgment-call escape hatch is a discipline the model will
+negotiate its way out of under pressure.
+
+Two more places the same distrust shows up in code:
+
+- **An empty diff is reported, never certified.** A reviewer handed nothing to
+  read returns no findings — which is indistinguishable from a clean review. So
+  an empty scope short-circuits to a recorded skip *before* a reviewer is
+  dispatched. Without that branch, the one observable symptom of a collapsed
+  review scope would be a pass.
+- **A skip is not a pass.** When the gate cannot run — no second harness, no
+  schema validator, no recorded base commit — it records that it did not run and
+  says why. It never degrades into silence that reads as success.
+
+---
+
+## The costs, stated plainly
+
+A framework that only lists its advantages is asking you to trust it. These are
+in the source with their reasoning attached.
+
+- **The reviewer will miss "this works, matches the plan, and the abstraction is
+  wrong."** That is a real category, and one a second model is unusually good at
+  spotting. It is excluded deliberately: the gate is unattended and auto-applies
+  fixes, so its false-positive rate matters more than its recall. The trade is
+  documented in the reviewer prompt as an accepted cost, not an oversight.
+- **A fix that cannot be expressed as a local text replacement is recorded and
+  not applied.** This is what structurally prevents an unattended reviewer from
+  landing broad speculative refactors — a constraint on shape rather than a
+  request for restraint.
+- **A green gate is not a correctness guarantee.** It reduces exposure to the same
+  class of error a human PR approval reduces, and leaves the same class behind.
+- **Blast-radius analysis is a partial mitigation**, not a complete one. The
+  reviewer reads callsites of changed symbols outside the diff; it does not read
+  your whole codebase.
+
+---
+
+## Check the claims
+
+Every claim above about Strikethroo is verifiable in this repository. That is
+intentional — you should not have to take positioning on faith.
+
+| Claim | Where to check |
+| --- | --- |
+| Round bound is compiled and cannot be raised by config | `MAX_REVIEW_ROUNDS` in `src/skill-scripts/shared/review-findings.ts` |
+| Missing attributes fail safe | `partitionFindings` in the same file |
+| Reviewer cannot be the implementer's harness | `discoverHarnesses` in `src/skill-scripts/shared/harness-discovery.ts` |
+| Subagent reports are not accepted as proof | `config/shared/verification-gate.md`, and the phase loop in `src/skill-prompts/sections/phase-execution-loop.md` |
+| Excuses are enumerated per skill | the rationalization tables in `src/skill-prompts/st-*.md` |
+| Reviewer detects and never fixes | the Role section of `src/skill-prompts/st-code-review.md` |
+| Empty scope skips instead of passing | the `empty-diff` branch in `src/skill-scripts/code-review.ts` |
+| Human approval gates the plan | `config/shared/clarification-gate.md` and [Workflow](workflow.html) |
+
+---
+
+## In one paragraph
+
+Strikethroo spends your attention at the plan, where a correction costs a
+sentence, and withholds it from the diff, where the same correction costs a review
+cycle. It treats the model — including a model reviewing another model — as a
+component with known failure modes rather than a colleague with good intentions,
+and it enforces the bounds that matter in compiled code rather than asking for
+them in prose. The result is not a trade of speed for quality. On a clock that
+starts at the idea and stops at the merge, it is the same thing.
+
+Next: the [Workflow Guide](workflow.html) for the step-by-step, or
+[Customization](customization.html) for the surfaces you own.

--- a/docs/why.md
+++ b/docs/why.md
@@ -8,26 +8,18 @@ description: "The design thesis: where human attention gets spent, and which gua
 # Why Strikethroo
 
 Most spec-driven frameworks optimize the input: better spec in, better code out,
-human catches the rest at the end. Strikethroo starts from three different
-premises.
-
-1. **The agent is an unreliable narrator of its own work.** A success report is a
-   claim, not evidence.
-2. **A second agent reviewing the first is also unreliable.** It will overstate
-   confidence and manufacture findings to justify its round.
-3. **The scarce resource is your attention, not tokens.**
-
-Everything below follows from those.
+human catches the rest at the end. Strikethroo starts from three premises instead:
+**the agent is an unreliable narrator of its own work**, **a second agent
+reviewing the first is also unreliable**, and **the scarce resource is your
+attention, not tokens**.
 
 ## Speed is measured at the wrong checkpoint
 
-The usual clock starts at the prompt and stops when code appears. The clock that
-pays your salary stops when the code is **merged** — and on that clock,
-generation is a rounding error next to the review rounds a fast-but-wrong draft
-costs you.
-
-Strikethroo is built against the second clock. That is not quality traded for
-speed. On that clock they are the same number.
+The usual clock stops when code appears. The clock that pays your salary stops
+when the code is **merged** — and there, generation is a rounding error next to
+the review rounds a fast-but-wrong draft costs you. Strikethroo targets the second
+clock. That is not quality traded for speed; on that clock they are the same
+number.
 
 ## Attention is the budget
 
@@ -36,35 +28,24 @@ So attention is rationed, not maximized:
 
 | Stage | Your involvement | Why |
 | --- | --- | --- |
-| **Plan** | Careful read, explicit approval gate | Corrections cost a sentence here |
+| **Plan** | Careful read, explicit approval gate | Corrections cost a sentence here. One question asked at a time, so it never gets skim-answered |
 | **Blueprint** | Quick verification pass | Structure, not substance |
 | **Execution** | None | Tasks carry runnable acceptance criteria |
 | **Result** | Careful read | "Does this do what I asked?" — the one question a machine can't answer |
 
-The clarification gate makes the first row work: **one question at a time**,
-multiple-choice where possible, explicit scope confirmation before anything is
-written. Decline a blocking question and planning *stops* rather than inventing
-an answer.
-
 The automated review gate is a **filter that runs before you look**, not a
 replacement for looking. It is scoped to requirement conformance and demonstrable
-defects, and explicitly forbidden from raising design opinions — because design
-judgment is what your read is being preserved for.
+defects, and forbidden from raising design opinions — that is what your read is
+preserved for.
 
 ## Guarantees are compiled, not requested
 
-**A rule in Markdown is a request. A rule in TypeScript is a guarantee.**
-
-- **Negotiable** — hooks at eleven workflow points, plan/task templates, project
-  context. Plain Markdown. Yours.
-- **Compiled** — termination bounds, severity/confidence floors, fail-safe
-  defaults, reviewer/implementer separation. Not read from a hook, so not
-  loosenable by editing one.
-
-Concretely: `MAX_REVIEW_ROUNDS` is a constant. A hook may state a round budget and
-it is honored — after clamping. **You can tighten the bound; nothing can raise
-it.** A finding that *omits* `severity` or `confidence` falls below every floor,
-so omission is never a route to auto-applying a change.
+**A rule in Markdown is a request. A rule in TypeScript is a guarantee.** Hooks
+and templates are yours to edit. Termination bounds, severity and confidence
+floors, fail-safe defaults, and reviewer/implementer separation are compiled, so
+no hook edit can loosen them: `MAX_REVIEW_ROUNDS` can be tightened by config and
+raised by nothing, and a finding that *omits* `severity` or `confidence` falls
+below every floor.
 
 The question to ask of any framework: **find the guarantee, then find where it is
 enforced.** If the only thing between you and an unbounded loop is a prompt asking
@@ -73,47 +54,29 @@ the model to stop, that is not a bound.
 ## Nobody marks their own homework
 
 The reviewer runs on a **different harness** than the one that wrote the code —
-the current harness is structurally removed from the candidate set, not merely
-deprioritized. The reviewer **detects and never fixes**; remediation is dispatched
-separately.
-
-This also reframes execution routing. Sending tasks to different models looks like
-cost optimization. Here it is the review gate's idea in another hat: **models fail
-differently, so a second model is an independent sample, not a cheaper one.**
-
-Two more places the distrust is structural rather than requested:
-
-- **An empty diff is reported, never certified.** A reviewer handed nothing
-  returns no findings — indistinguishable from a clean review. Empty scope
-  short-circuits to a recorded skip before any reviewer is dispatched.
-- **A skip is not a pass.** No second harness, no validator, no base commit → the
-  gate records that it did not run, and why. It never degrades into silence that
-  reads as success.
+structurally excluded from the candidate set, not merely deprioritized — and it
+**detects but never fixes**. Same reason execution routing exists: models fail
+differently, so a second model is an independent sample, not a cheaper one.
 
 ## The costs
 
-- **The reviewer will miss "works, matches the plan, wrong abstraction."** Real
-  category, deliberately excluded: the gate is unattended and auto-applies fixes,
-  so false-positive rate matters more than recall.
-- **A fix that isn't a local text replacement is recorded, not applied.** This is
-  what structurally prevents speculative refactors landing unattended.
-- **A green gate is not a correctness guarantee.** It reduces the same class of
-  error a human PR approval reduces, and leaves the same class behind.
-- **Blast-radius analysis is partial.** Callsites of changed symbols, not your
-  whole codebase.
+- **The reviewer will miss "works, matches the plan, wrong abstraction."**
+  Deliberately excluded: the gate is unattended and auto-applies fixes, so
+  false-positive rate matters more than recall.
+- **A fix that isn't a local text replacement is recorded, not applied** — what
+  structurally prevents speculative refactors landing unattended.
+- **A green gate is not a correctness guarantee.** Same class of error a human PR
+  approval catches, and the same class left behind.
 
 ## Check the claims
 
 | Claim | Where |
 | --- | --- |
-| Round bound compiled, not raisable by config | `MAX_REVIEW_ROUNDS` in `src/skill-scripts/shared/review-findings.ts` |
+| Round bound compiled, not raisable by config | `MAX_REVIEW_ROUNDS`, `src/skill-scripts/shared/review-findings.ts` |
 | Missing attributes fail safe | `partitionFindings`, same file |
-| Reviewer can't be the implementer's harness | `discoverHarnesses` in `src/skill-scripts/shared/harness-discovery.ts` |
+| Reviewer can't be the implementer's harness | `discoverHarnesses`, `src/skill-scripts/shared/harness-discovery.ts` |
 | Subagent reports aren't proof | `config/shared/verification-gate.md` |
-| Excuses enumerated per skill | rationalization tables in `src/skill-prompts/st-*.md` |
 | Reviewer detects, never fixes | Role section, `src/skill-prompts/st-code-review.md` |
-| Empty scope skips instead of passing | `empty-diff` branch in `src/skill-scripts/code-review.ts` |
-| Human approval gates the plan | `config/shared/clarification-gate.md`, [Workflow](workflow.html) |
+| Human approval gates the plan | `config/shared/clarification-gate.md` |
 
-Next: the [Workflow Guide](workflow.html), or [Customization](customization.html)
-for the surfaces you own.
+Next: the [Workflow Guide](workflow.html), or [Customization](customization.html).

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -7,7 +7,7 @@ description: "Step-by-step workflow with commands and visual guides"
 
 # Workflow Guide
 
-Strikethroo breaks complex work into three steps -- planning, task generation, and execution -- each delivered as an Agent Skill that loads automatically when you describe what you need. An optional fourth step, automated code review, runs at the end.
+Strikethroo runs on **two commands**: `st-create-plan` to draft the work, and `st-execute-blueprint` to build it. Each is an Agent Skill that loads automatically when you describe what you need. Task decomposition happens inside execution, and an optional automated code review runs at the end.
 
 ## The Workflow
 
@@ -16,26 +16,23 @@ flowchart LR
     A[Work Order] --> B[Plan]
     B --> C{Review}
     C -->|Edit| B
-    C -->|Approve| D[Tasks]
-    D --> E{Verify}
-    E --> G[Execute]
+    C -->|Approve| G["Execute<br/>(generates tasks)"]
     G --> H["Code Review<br/>(optional)"]
     H -->|Fix| G
     H -->|Pass| J[Done]
 
     style A fill:#ffebee
     style B fill:#e3f2fd
-    style D fill:#f3e5f5
     style G fill:#e8f5e8
     style H fill:#fff3cd
     style J fill:#c8e6c9
 ```
 
-Human gates wrap the first three steps: you **review** the plan, **verify** the blueprint, and **review** the executed result -- looping back to edit whenever something is off. The plan and the result get a careful read; the blueprint just gets a quick validation pass before execution. An optional automated review gate runs after execution: a discovered second harness critiques the cumulative diff and drives remediation for high-confidence findings.
+One human gate sits before any code exists: you **review** the plan, looping back to edit until it is right. Then you run it, and **review** the result. An optional automated review gate runs in between: a discovered second harness critiques the cumulative diff and drives remediation for high-confidence findings, before your read of the result.
 
-That distribution of effort is deliberate, not incidental. Attention is **rationed toward the point where a correction is cheapest** -- a misunderstanding costs one sentence to fix in the plan and a full review cycle to fix in the diff. The automated gate is a filter that runs *before* your read of the result, so that read lands on "this doesn't do what I asked" rather than "you forgot the null check." See [Why Strikethroo](why.html) for the reasoning in full.
+That distribution of effort is deliberate, not incidental. Attention is **rationed toward the point where a correction is cheapest** -- a misunderstanding costs one sentence to fix in the plan and a full review cycle to fix in the diff. So the plan gets your careful read, and the task blueprint gets generated for you rather than reviewed by you. See [Why Strikethroo](why.html) for the reasoning in full.
 
-{% include callout.html variant="warning" content="The review gates are where you catch scope creep and wrong turns. Do not skip them." %}
+{% include callout.html variant="warning" content="The plan review is where you catch scope creep and wrong turns, for a fraction of what catching them later costs. Do not skip it." %}
 
 ## Step-by-Step
 
@@ -62,7 +59,10 @@ Prefer reading it rendered? `npx strikethroo serve` shows the plan document with
 
 [![Plan Detail, Plan tab]({{ '/assets/plan-detail-plan.png' | relative_url }})]({{ '/assets/plan-detail-plan.png' | relative_url }})
 
-### 3. Generate Tasks
+<details markdown="1">
+<summary><strong>Optional detour: build the blueprint separately</strong></summary>
+
+Most runs go straight from the approved plan to execution, which generates the blueprint itself. Run task generation on its own only when you want to inspect or hand-tune the decomposition first -- an unusually large plan, or one whose phase ordering you want to see before committing to it.
 
 > /st-generate-tasks 1
 
@@ -70,37 +70,29 @@ The `st-generate-tasks` skill breaks the plan into atomic tasks (1-2 skills each
 
 **Output**: `.ai/strikethroo/plans/01--user-authentication/tasks/*.md`
 
-The blueprint's phases -- groups of tasks that run in parallel -- render as swimlanes in the web app:
+If you do look, skim rather than read line by line: check that nothing outside the original scope slipped in, that no task carries 3+ skills, and that the dependency order is sane. Fix a task file directly if something is off. Save the careful reading for the plan and the result.
+
+The blueprint's phases -- groups of tasks that run in parallel -- render as swimlanes in the web app, and a wrong ordering is easiest to spot on the dependency graph:
 
 [![Plan Detail, Tasks swimlanes]({{ '/assets/plan-detail-tasks-swimlanes.png' | relative_url }})]({{ '/assets/plan-detail-tasks-swimlanes.png' | relative_url }})
 
-### 4. Validate the Tasks
-
-The task documents don't need a line-by-line review -- just a quick validation pass before you let it run. Skim the `tasks/` directory and confirm:
-- Nothing obviously outside the original scope slipped in
-- No task is overloaded (3+ skills signals it should be split)
-- Each task has a `complexity_score` between 1 and 10
-- The dependency order is sane
-
-If something looks wrong, fix the task file directly; otherwise move straight to execution. Save the careful reading for the plan (step 2) and the result (step 6).
-
-A wrong ordering is easiest to spot on the dependency graph -- a live mermaid render of the same task files:
-
 [![Plan Detail, Graph tab]({{ '/assets/plan-detail-graph.png' | relative_url }})]({{ '/assets/plan-detail-graph.png' | relative_url }})
 
-### 5. Execute the Blueprint
+</details>
+
+### 3. Execute the Blueprint
 
 > /st-execute-blueprint 1
 
 The `st-execute-blueprint` skill runs tasks grouped into phases. Before phases begin, it runs `create-feature-branch.cjs` to create a plan feature branch when appropriate (skipped when not on `main`/`master` — that is expected, not a failure). Before each phase, the skill runs `check-phase-readiness.cjs`, then the [`PRE_PHASE`](customization.html#pre_phase) hook. Independent tasks run in parallel within the phase. For routed tasks, dispatch selects a target from the persisted profile immediately before delegation; native/current-harness targets skip availability probes, while external harnesses are checked and unavailable targets are avoided on retry. For every task, [`PRE_TASK_ASSIGNMENT`](customization.html#pre_task_assignment) runs before dispatch and [`PRE_TASK_EXECUTION`](customization.html#pre_task_execution) runs on the task agent before implementation. [`POST_ERROR_DETECTION`](customization.html#post_error_detection) runs if a task fails, and [`POST_PHASE`](customization.html#post_phase) runs after each phase completes.
 
-{% include callout.html variant="note" content="If you skipped step 3, `st-execute-blueprint` auto-generates the tasks and the blueprint before starting." %}
+Before any of that, if the plan has no tasks yet, the skill generates them: it breaks the plan into atomic tasks (1-2 skills each), maps dependencies, assigns every task a `complexity_score`, and assembles the phase-grouped blueprint. That is the normal path -- you do not run a separate task-generation command.
 
 The `st-execute-blueprint` skill drives progress end to end: it updates task statuses as phases complete, and you can inspect plan and task files directly under `.ai/strikethroo/plans/` at any point. Prefer a visual view? Run `npx strikethroo serve` to watch progress in [Visualizations](visualizations.html), the web app that renders plans, tasks, and the dependency graph live from those same files. From the board you can drill straight down into any task:
 
 <video class="wide-video" controls preload="metadata" src="{{ '/assets/nav-plans-to-task-detail.webm' | relative_url }}"></video>
 
-### 6. Review the Results
+### 4. Review the Results
 
 When the last phase finishes, the [`POST_EXECUTION`](customization.html#post_execution) hook runs before the summary is written and the plan is archived.
 
@@ -115,7 +107,7 @@ Each task's implementation notes capture what actually happened during execution
 
 [![Task Detail, Implementation Notes]({{ '/assets/task-detail-implementation-notes.png' | relative_url }})]({{ '/assets/task-detail-implementation-notes.png' | relative_url }})
 
-### 7. Automated Code Review (Optional)
+### 5. Automated Code Review (Optional)
 
 After `POST_EXECUTION` reports green, an optional code review gate runs if a second harness is discovered and the [`CODE_REVIEW`](customization.html#code_review) hook is present and non-empty. A discovered reviewer harness critiques the cumulative diff against the plan's requirements and emits schema-validated findings.
 
@@ -156,7 +148,7 @@ The reviewed scope runs from a base commit recorded before phase execution again
 
 ## Alternative: Automated Workflow
 
-For clear requirements with minimal ambiguity, the `st-full-workflow` skill chains all three steps end-to-end. Ask your assistant to run the full Strikethroo workflow and it handles plan creation, task generation, and execution in one pass.
+For clear requirements with minimal ambiguity, the `st-full-workflow` skill runs the whole thing end-to-end, skipping the plan-approval gate. Ask your assistant to run the full Strikethroo workflow and it handles plan creation, task generation, and execution in one pass.
 
 ## Advanced Patterns
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Workflow Guide
-nav_order: 2
+nav_order: 3
 description: "Step-by-step workflow with commands and visual guides"
 ---
 
@@ -32,6 +32,8 @@ flowchart LR
 ```
 
 Human gates wrap the first three steps: you **review** the plan, **verify** the blueprint, and **review** the executed result -- looping back to edit whenever something is off. The plan and the result get a careful read; the blueprint just gets a quick validation pass before execution. An optional automated review gate runs after execution: a discovered second harness critiques the cumulative diff and drives remediation for high-confidence findings.
+
+That distribution of effort is deliberate, not incidental. Attention is **rationed toward the point where a correction is cheapest** -- a misunderstanding costs one sentence to fix in the plan and a full review cycle to fix in the diff. The automated gate is a filter that runs *before* your read of the result, so that read lands on "this doesn't do what I asked" rather than "you forgot the null check." See [Why Strikethroo](why.html) for the reasoning in full.
 
 {% include callout.html variant="warning" content="The review gates are where you catch scope creep and wrong turns. Do not skip them." %}
 


### PR DESCRIPTION
This PR reframes Strikethroo's core value proposition from "spec-driven development that fits your codebase" to "spec-driven development optimized for time-to-merge, not time-to-first-draft." The change reflects a shift in emphasis toward the actual cost of development — review cycles and rework — rather than generation speed alone.

## Summary of changes

**New documentation:**
- Added `docs/why.md`: A comprehensive design thesis explaining the three core premises (agent unreliability, reviewer unreliability, attention as the scarce resource), the cost model (speed measured at merge, not at first draft), and the structural guarantees that distinguish Strikethroo from other spec-driven frameworks. Includes a verification table mapping claims to source locations.

**Messaging updates across all user-facing surfaces:**
- Repositioned the four headline value propositions: "You review the plan, not the diff" (where corrections cost a sentence vs. a review cycle), "Guarantees are compiled, not requested" (Markdown is a request; TypeScript is a guarantee), "Nobody marks their own homework" (reviewer harness separation), and "Bends to your conventions" (hooks and templates).
- Removed emphasis on "no API keys" and "harness-agnostic skills" from the headline four, moved to a callout note as "also true, and less interesting."
- Updated workflow description from "three steps" (plan, tasks, execute) to "two commands" (`st-create-plan`, `st-execute-blueprint`), with task generation as an optional detour rather than a required step.

**Workflow documentation refinement:**
- Clarified that `st-execute-blueprint` generates the blueprint itself when one doesn't exist, making task generation a separate-but-optional step rather than a required phase.
- Reframed the attention distribution: plan review gets careful reading (where corrections are cheapest), blueprint gets a quick skim (generated for you, not reviewed by you), result gets careful reading.
- Updated nav_order values to reflect new document hierarchy (why.md at position 2, pushing workflow, customization, reference, faq, visualizations, and migration down by one).

**FAQ and reference updates:**
- Expanded comparison section with explicit positioning against other spec-driven frameworks, emphasizing the three premises and the negotiable/compiled distinction.
- Updated workflow FAQ to reflect two-command model and clarify when task generation is worth running separately.
- Updated hook count from nine to eleven across all documentation.

## Implementation details

The design thesis in `docs/why.md` is structured to be verifiable: each claim includes a pointer to the source file and location where it is enforced. This supports the core argument that guarantees are compiled rather than requested — users can check that `MAX_REVIEW_ROUNDS` cannot be raised by config, that missing attributes fail safe, that the reviewer harness is structurally excluded, etc.

The messaging shift is consistent across README.md, docs/index.md, and all supporting documentation, ensuring the value proposition is clear at every entry point.
