### PR TITLE
docs: correct review-gate scope and serve mutability claims

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -70,9 +70,15 @@ npx strikethroo serve [options]
 Boots a local web app over an initialized `.ai/strikethroo/` workspace: a dependency-light Node server hosts the prebuilt single-page viewer as static assets, exposes a read-only JSON API over the workspace model, and streams a coalesced change event over Server-Sent Events whenever the workspace mutates on disk. Run it from inside an initialized workspace; if none is found it prints guidance to run `init` and exits without binding.
 
 {% capture serve_readonly %}
-The viewer is **read-only except for one permitted mutation: the archive action.** A plan whose tasks are all complete (derived state `done`) shows an **Archive** control; confirming it issues `POST /api/plans/:id/archive`, which atomically renames that plan's directory from `plans/` to `archive/`. It is strictly a directory move &mdash; no files are deleted or edited, and only `done` plans are accepted. This is the manual escape hatch for plans that are done but not yet archived; it does not replace the automatic archival the `st-execute-blueprint` skill performs on successful completion.
+The viewer is **read-only except for two sanctioned mutations: the archive action and the config editor.**
+
+**Archive.** A plan whose tasks are all complete (derived state `done`) shows an **Archive** control; confirming it issues `POST /api/plans/:id/archive`, which atomically renames that plan's directory from `plans/` to `archive/`. It is strictly a directory move &mdash; no files are deleted or edited, and only `done` plans are accepted. This is the manual escape hatch for plans that are done but not yet archived; it does not replace the automatic archival the `st-execute-blueprint` skill performs on successful completion.
+
+**Config editor.** The **Customize** section edits your workspace configuration in place, issuing `PUT /api/config/:kind/:id` to overwrite a single existing file. It is overwrite-only and never creates, deletes, or renames: `kind` is restricted to `hooks` and `templates`, each resolving to one flat `config/<kind>/<id>.md` file, plus the special `workspace` kind behind the Customize Config form, which maps to `config/config.yaml`. Anything outside that allowlist &mdash; path separators, `..`, an unknown kind, a file that does not already exist &mdash; is rejected. Saving `config.yaml` through the form preserves unrecognized top-level sections but **does not preserve comments**.
+
+Separately, the **Self Review** action (`POST /api/self-review`) writes nothing itself, but does launch an external reviewer process on your machine.
 {% endcapture %}
-{% include callout.html variant="note" title="READ-ONLY, WITH ONE EXCEPTION" content=serve_readonly %}
+{% include callout.html variant="note" title="READ-ONLY, WITH TWO EXCEPTIONS" content=serve_readonly %}
 
 **Optional flags:**
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -89,6 +89,8 @@ The LLM verifies all tasks reached `completed` status, checks that documentation
 
 Terminal review gate, terminal only — runs once per plan, creates no task files, never mutates the blueprint. When a second harness is discovered and this hook is present and non-empty, a reviewer harness critiques the cumulative diff and emits schema-validated findings (`review.xml`). Findings at or above configured severity and confidence floors are dispatched to the implementer route for remediation; any applied fix forces a full `POST_EXECUTION` re-run before re-verification. Rounds are bounded and enforced in code; a user editing the hook cannot disable termination.
 
+**Reviewed scope**: a two-dot diff from a base commit recorded before phase execution against the **working tree**, so committed phase work and uncommitted fixes are both included. Untracked, unignored files are included too — the gate synthesizes an add-diff for each with `git diff --no-index` against `/dev/null`, so nothing needs to be staged or committed for the reviewer to see it, and the gate never writes to the git index.
+
 **Configuration**: The hook body specifies the mandate — which finding categories (correctness, design, security, etc.) are in scope, the minimum severity floor (`critical`, `major`, `minor`, `info`), the minimum confidence floor (`high`, `medium`, `low`), and the maximum round budget (default 3, clamped in code to a hardcoded `MAX_REVIEW_ROUNDS`). Any findings below either floor are recorded but never auto-fixed.
 
 **To disable**: Empty or delete this file. The gate skips cleanly and notes it in the execution summary. No error. `init` preserves your edits on re-run unless you pass `--force`.
@@ -101,7 +103,8 @@ Terminal review gate, terminal only — runs once per plan, creates no task file
 - Findings do not survive a fresh clone — `init` ships a workspace `.gitignore` that excludes `plans/*/review/` and `archive/*/review/`, so the gate never sees its own output as changed content. That exclusion covers review artifacts only; whether you track the rest of `.ai/strikethroo/` is your project's call.
 - Conformance-only scope has a blind spot — correct code matching the plan but badly abstracted passes.
 - Blast-radius checking is partial — the full `POST_EXECUTION` re-run is the real catcher.
-- Untracked files are outside the review scope — the diff runs from the recorded base commit against the working tree, so an uncommitted change to a tracked file is reviewed, while a brand-new file nothing has staged is invisible. Widening this would mean writing to the git index, which the gate deliberately does not do.
+- Generated and vendored files are outside the review scope — paths that `.gitattributes` marks `linguist-generated` or `linguist-vendored` are dropped from the diff, so changes to build output or vendored code are never reviewed. A finding against generated code is unfixable anyway: the fix is applied as a text replacement, the mandatory `POST_EXECUTION` re-run regenerates the file, and the next round raises the identical finding.
+- Ignored files are outside the review scope — the gate honours your ignore rules, which is also what keeps its own `review/` output from entering the next round's diff.
 
 ### Workflow Control Hooks
 

--- a/docs/visualizations.md
+++ b/docs/visualizations.md
@@ -2,12 +2,12 @@
 layout: default
 title: Visualizations
 nav_order: 7
-description: "See your plans, tasks, dependency graph, and archive in a live, read-only web app"
+description: "See your plans, tasks, dependency graph, and archive in a live local web app"
 ---
 
 # Visualizations
 
-Strikethroo stores everything as Markdown. To *see* where your work stands, run the read-only web app from any initialized project:
+Strikethroo stores everything as Markdown. To *see* where your work stands, run the local web app from any initialized project:
 
 ```bash
 npx strikethroo serve

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -121,7 +121,7 @@ After `POST_EXECUTION` reports green, an optional code review gate runs if a sec
 
 The review never creates task files and never mutates the execution blueprint. Findings are written to the plan directory under `review/` and are visible via `serve`.
 
-The reviewed scope runs from a base commit recorded before phase execution against the working tree, so committed phase work and uncommitted fixes are both in scope. Untracked files are not — see [Customization](customization.html#code_review) for the complete list of limitations.
+The reviewed scope runs from a base commit recorded before phase execution against the working tree, so committed phase work, uncommitted fixes, and untracked new files are all in scope — nothing needs to be staged or committed for the reviewer to see it. Ignored, generated, and vendored paths are excluded; see [Customization](customization.html#code_review) for the complete list of limitations.
 
 **To disable:** Edit or delete `.ai/strikethroo/config/hooks/CODE_REVIEW.md`. The gate skips cleanly with a note in the execution summary.
 

--- a/templates/strikethroo/gitignore
+++ b/templates/strikethroo/gitignore
@@ -7,9 +7,12 @@
 # and each round supersedes the last.
 #
 # Ignoring it also keeps the gate from reviewing itself. The reviewed diff runs
-# from the recorded base against the working tree, so a committed round-1
-# review.xml would appear in round 2's diff as ordinary changed content.
-# Untracked files never enter that diff.
+# from the recorded base against the working tree, and untracked files are in
+# scope — the gate synthesizes an add-diff for each one. What keeps review
+# output out of the next round is these ignore rules: the gate enumerates
+# untracked paths with `git ls-files --others --exclude-standard`, which applies
+# them, so a round-1 review.xml is invisible to round 2 whether or not anything
+# committed it.
 #
 # Both locations are listed because a completed plan directory is moved from
 # plans/ to archive/ wholesale, carrying its review/ directory with it.


### PR DESCRIPTION
Closes #71. Closes #27.

Two documentation defects batched together — both are cases of the docs asserting behaviour the code does not have. Documentation only; no source change, and none should be made. In both cases the implementation is correct and the docs are the stale side.

## #71 — untracked files are *in* the review gate's scope

The gate has included untracked, unignored files since it shipped. `_readCumulativeDiff` unions the tracked `git diff <base>` with a synthesized add-diff per untracked path (`git diff --no-index` against `/dev/null`, over `git ls-files --others --exclude-standard`). Three places said the opposite:

| Location | Was |
|---|---|
| `docs/customization.md` | "Untracked files are outside the review scope … a brand-new file nothing has staged is invisible." |
| `docs/workflow.md` | "Untracked files are not [in scope]." |
| `templates/strikethroo/gitignore` | "Untracked files never enter that diff." |

The stated rationale was also backwards: it claimed widening the scope "would mean writing to the git index, which the gate deliberately does not do." The `--no-index` synthesis exists *precisely* so the gate can read untracked files without touching the index. Both operations are reads.

The `gitignore` copy is the one worth flagging: `init` delivers it into every user workspace, so that comment is the most widely distributed copy of the false claim. It was also wrong about its own purpose — what keeps the gate from reviewing its own `review/` output is `--exclude-standard` honouring those very ignore rules, not a blanket exclusion of untracked content. Rewritten to say so.

**Secondary defect, same block.** The customization.md list is billed as "the complete list" but omitted a real limitation: paths `.gitattributes` marks `linguist-generated` or `linguist-vendored` are dropped from the diff (`excludedPaths` / `attributeExcluded`), so generated and vendored changes are never reviewed. Added as a bullet, with the reason a finding against generated code is unfixable by construction. Added an ignored-paths bullet too, since that is the mechanism the `.gitignore` comment now points at. The positive scope statement moved into a new **Reviewed scope** paragraph, where it belongs — a limitations list is the wrong place to describe what *is* covered.

The other five bullets were checked against the implementation and are accurate; unchanged. Per the issue, the "findings do not survive a fresh clone" bullet at customization.md:101 is explicitly out of scope and left as written.

## #27 — serve exposes two sanctioned writes, not one

`docs/cli-reference.md` claimed the viewer is "read-only except for one permitted mutation: the archive action." There are two: archive (`POST /api/plans/:id/archive`) and the config editor (`PUT /api/config/:kind/:id`), which overwrites hook/template files and `config.yaml` in place. `AGENTS.md` already states the correct model; the public docs lagged.

Rewrote the callout to cover both, documenting the config-write guard (overwrite-only, `kind` allowlisted to `hooks`/`templates` plus the special `workspace` kind, traversal rejected) and the fact that saving `config.yaml` does not preserve comments. Also notes that `POST /api/self-review` writes nothing itself but launches an external process. Callout title updated accordingly.

**One thing beyond the filed scope**, flagged for your call: `docs/visualizations.md` called it a "read-only web app" in both its frontmatter description and opening line, then admitted "one of only two writes the app ever makes to disk" two sections later. Same defect class, self-contradicting within one page, one word each — fixed here. Easy to drop if you would rather keep this PR strictly to the two issues.

`docs/_site/` needs no regeneration — it is not tracked in git.

## Verification

- Full `npm test` gate green via the pre-commit hook: 412 unit tests, 37 e2e.
- Prettier clean on all four docs.
- The four integration tests at `code-review.integration.test.ts:355-414` already assert the untracked-inclusion behaviour this PR documents.

Note for local runs: the e2e half needs `npx playwright install-deps chromium` in a fresh devcontainer, otherwise Chromium fails to launch on a missing `libnspr4.so`.